### PR TITLE
Addressing nullref on default settings

### DIFF
--- a/src/DocumentDB.ChangeFeedProcessor/ChangeFeedHostOptions.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/ChangeFeedHostOptions.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor
             LeaseExpirationInterval = DefaultExpirationInterval;
             FeedPollDelay = DefaultFeedPollDelay;
             QueryPartitionsMaxBatchSize = DefaultQueryPartitionsMaxBatchSize;
+            CheckpointFrequency = new CheckpointFrequency();
         }
 
         /// <summary>

--- a/src/DocumentDB.ChangeFeedProcessor/FeedProcessor/AutoCheckpointer.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/FeedProcessor/AutoCheckpointer.cs
@@ -52,6 +52,11 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessor
 
         private bool IsCheckpointNeeded()
         {
+            if(!checkpointFrequency.ProcessedDocumentCount.HasValue && !checkpointFrequency.TimeInterval.HasValue)
+            {
+                return true;
+            }
+
             if (processedDocCount >= checkpointFrequency.ProcessedDocumentCount)
                 return true;
 

--- a/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/PartitionManagerBuilder.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/PartitionManagerBuilder.cs
@@ -45,13 +45,14 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement
                                                                         IDocumentClientEx feedDocumentClient, DocumentCollectionInfo feedCollectionInfo,
                                                                         ChangeFeedHostOptions options)
         {
+            if (leaseCollectionLocation == null) throw new InvalidOperationException(nameof(leaseCollectionLocation) + " was not specified");
+            leaseDocumentClient = leaseDocumentClient ?? leaseCollectionLocation.CreateDocumentClient();
+
             DocumentCollection documentCollection = await leaseDocumentClient.GetDocumentCollectionAsync(leaseCollectionLocation).ConfigureAwait(false);
             string leaseStoreCollectionLink = documentCollection.SelfLink;
 
-            if (this.leaseManager != null)
+            if (this.leaseManager == null)
             {
-                if (leaseCollectionLocation == null) throw new InvalidOperationException(nameof(leaseCollectionLocation) + " was not specified");
-                leaseDocumentClient = leaseDocumentClient ?? leaseCollectionLocation.CreateDocumentClient();
                 this.leaseManager = CreateLeaseManager(leasePrefix, leaseStoreCollectionLink);
             }
 


### PR DESCRIPTION
When the Host is created with default settings on a [simple project](https://github.com/Azure/azure-documentdb-dotnet/tree/master/samples/ChangeFeedMigrationTool), the Host throws a null reference on multiple points (`leaseCollectionClient` and `checkpointFrequency`).

This PR fixes #3 