### PR TITLE
don't stop load balancer loop in case of exceptions

### DIFF
--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/PartitionManagement/PartitionLoadBalancerTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/PartitionManagement/PartitionLoadBalancerTests.cs
@@ -58,12 +58,12 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.PartitionManag
 
             public Task InitializeAsync()
             {
-                return Task.FromResult(false);
+                return Task.CompletedTask;
             }
 
             public Task ShutdownAsync()
             {
-                return Task.FromResult(false);
+                return Task.CompletedTask;
             }
         }
     }


### PR DESCRIPTION
The problem with existing load balancer is that it stops its loop in case of any exceptions and it can never be propagated (the RunAsync task is not awaited, the main loop starts in Start method and can be cancelled only when Stop is called). The proposal is to continue iterations in case of any exceptions