### PR TITLE
Create new version of the ChangeFeedObserverCloserReason enum to reso…

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,14 @@ For illustration, let's assume we are processing the change feed from **Monitore
 
 ### Example
 ```csharp
-using Microsoft.Azure.Documents;
-using Microsoft.Azure.Documents.ChangeFeedProcessor;
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-
+// Observer.cs
 namespace Sample
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Documents;
     using Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing;
 
     class SampleObserver : IChangeFeedObserver
@@ -62,7 +61,7 @@ namespace Sample
 
         public Task OpenAsync(IChangeFeedObserverContext context)
         {
-            return Task.CompletedTask;
+             return Task.CompletedTask;
         }
 
         public Task ProcessChangesAsync(IChangeFeedObserverContext context, IReadOnlyList<Document> docs, CancellationToken cancellationToken)
@@ -71,12 +70,26 @@ namespace Sample
             return Task.CompletedTask;
         }
     }
+}
+
+// Main.cs
+namespace Sample
+{
+    using System;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor.Logging;
 
     class ChangeFeedProcessorSample
     {
+        public static void Run()
+        {
+            RunAsync().Wait();
+        }
+
         static async Task RunAsync()
         {
-            DocumentCollectionInfo CollectionInfo = new DocumentCollectionInfo()
+            DocumentCollectionInfo feedCollectionInfo = new DocumentCollectionInfo()
             {
                 DatabaseName = "DatabaseName",
                 CollectionName = "MonitoredCollectionName",
@@ -84,10 +97,10 @@ namespace Sample
                 MasterKey = "-- the auth key"
             };
 
-            DocumentCollectionInfo LeaseCollectionInfo = new DocumentCollectionInfo()
+            DocumentCollectionInfo leaseCollectionInfo = new DocumentCollectionInfo()
             {
                 DatabaseName = "DatabaseName",
-                CollectionName = ";eases",
+                CollectionName = "leases",
                 Uri = new Uri("https://sampleservice.documents.azure.com:443/"),
                 MasterKey = "-- the auth key"
             };
@@ -95,8 +108,8 @@ namespace Sample
             var builder = new ChangeFeedProcessorBuilder();
             var processor = await builder
                 .WithHostName("SampleHost")
-                .WithFeedCollection(CollectionInfo)
-                .WithLeaseCollection(LeaseCollectionInfo)
+                .WithFeedCollection(feedCollectionInfo)
+                .WithLeaseCollection(leaseCollectionInfo)
                 .WithObserver<SampleObserver>()
                 .BuildAsync();
 
@@ -114,7 +127,8 @@ namespace Sample
 The following v1 API from v1 is is present in v2 for backward compatibility but is marked obsolete. It is recommended to use new API.
 
 - Microsoft.Azure.Documents.ChangeFeedProcessor.ChangeFeedEventHost.<br/> Use Microsoft.Azure.Documents.ChangeFeedProcessor.ChangeFeedProcessorBuilder.
-- Microsoft.Azure.Documents.ChangeFeedProcessor.ChangeFeedObserverContext.<br/> Use Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing.IChangeFeedObserverContext.
+- Microsoft.Azure.Documents.ChangeFeedProcessor.ChangeFeedObserverContext.<br/> Use Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing.IChangeFeedObserverContext that has ProcessChangesAsync taking new CancellationToken parameter.
+- Microsoft.Azure.Documents.ChangeFeedProcessor.ChangeFeedObserverCloseReason.<br/> Use Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing.ChangeFeedObserverCloseReason.
 - Microsoft.Azure.Documents.ChangeFeedProcessor.IChangeFeedObserver.<br/> Use Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing.IChangeFeedObserver.
 - Microsoft.Azure.Documents.ChangeFeedProcessor.IChangeFeedObserverFactory.<br/> Use Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing.IChangeFeedObserverFactory.
 

--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/ChangeFeedProcessorTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/ChangeFeedProcessorTests.cs
@@ -2,20 +2,21 @@
 // Copyright (c) Microsoft Corporation.  Licensed under the MIT license.
 //----------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Azure.Documents.ChangeFeedProcessor.DataAccess;
-using Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement;
-using Microsoft.Azure.Documents.Client;
-using Microsoft.Azure.Documents.Linq;
-using Moq;
-using Xunit;
-
 namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor.DataAccess;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement;
+    using Microsoft.Azure.Documents.Client;
+    using Microsoft.Azure.Documents.Linq;
+    using Moq;
+    using Xunit;
+
     [Trait("Category", "Gated")]
     public class ChangeFeedProcessorTests
     {
@@ -35,8 +36,8 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests
         };
 
         private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
-        private readonly FeedProcessing.IChangeFeedObserver observer;
-        private readonly FeedProcessing.IChangeFeedObserverFactory observerFactory;
+        private readonly IChangeFeedObserver observer;
+        private readonly IChangeFeedObserverFactory observerFactory;
         private readonly ChangeFeedProcessorBuilder builder = new ChangeFeedProcessorBuilder();
 
         public ChangeFeedProcessorTests()
@@ -114,17 +115,17 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests
                 .WithLeaseCollection(collectionInfo)
                 .WithLeaseDocumentClient(leaseDocumentClient);
 
-            this.observer = Mock.Of<FeedProcessing.IChangeFeedObserver>();
+            this.observer = Mock.Of<IChangeFeedObserver>();
             Mock.Get(observer)
                 .Setup(feedObserver => feedObserver
-                    .ProcessChangesAsync(It.IsAny<FeedProcessing.ChangeFeedObserverContext>(), It.IsAny<IReadOnlyList<Document>>(), It.IsAny<CancellationToken>()))
+                    .ProcessChangesAsync(It.IsAny<ChangeFeedObserverContext>(), It.IsAny<IReadOnlyList<Document>>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(false))
                 .Callback(cancellationTokenSource.Cancel);
             Mock.Get(observer)
-                .Setup(observer => observer.OpenAsync(It.IsAny<FeedProcessing.ChangeFeedObserverContext>()))
+                .Setup(observer => observer.OpenAsync(It.IsAny<ChangeFeedObserverContext>()))
                 .Returns(Task.FromResult(false));
 
-            this.observerFactory = Mock.Of<FeedProcessing.IChangeFeedObserverFactory>();
+            this.observerFactory = Mock.Of<IChangeFeedObserverFactory>();
             Mock.Get(observerFactory)
                 .Setup(observer => observer.CreateObserver())
                 .Returns(observer);

--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/Exceptions/PartitionExceptionsTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/Exceptions/PartitionExceptionsTests.cs
@@ -2,21 +2,21 @@
 // Copyright (c) Microsoft Corporation.  Licensed under the MIT license.
 //----------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Azure.Documents.ChangeFeedProcessor.DataAccess;
-using Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions;
-using Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing;
-using Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.Utils;
-using Microsoft.Azure.Documents.Client;
-using Moq;
-using Xunit;
-
 namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.Exceptions
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor.DataAccess;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.Utils;
+    using Microsoft.Azure.Documents.Client;
+    using Moq;
+    using Xunit;
+
     [Trait("Category", "Gated")]
     public class PartitionExceptionsTests
     {
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.Exceptions
         private readonly IChangeFeedDocumentClient docClient;
         private readonly IChangeFeedDocumentQuery<Document> documentQuery;
         private readonly IFeedResponse<Document> feedResponse;
-        private readonly FeedProcessing.IChangeFeedObserver observer;
+        private readonly IChangeFeedObserver observer;
         private readonly List<Document> documents;
 
         public PartitionExceptionsTests()
@@ -64,10 +64,10 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.Exceptions
                 .Setup(ex => ex.CreateDocumentChangeFeedQuery(processorSettings.CollectionSelfLink, It.IsAny<ChangeFeedOptions>()))
                 .Returns(documentQuery);
 
-            observer = Mock.Of<FeedProcessing.IChangeFeedObserver>();
+            observer = Mock.Of<IChangeFeedObserver>();
             Mock.Get(observer)
                 .Setup(feedObserver => feedObserver
-                    .ProcessChangesAsync(It.IsAny<FeedProcessing.ChangeFeedObserverContext>(), It.IsAny<IReadOnlyList<Document>>(), It.IsAny<CancellationToken>()))
+                    .ProcessChangesAsync(It.IsAny<ChangeFeedObserverContext>(), It.IsAny<IReadOnlyList<Document>>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(false))
                 .Callback(cancellationTokenSource.Cancel);
 
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.Exceptions
             Mock.Get(observer)
                 .Verify(feedObserver => feedObserver
                         .ProcessChangesAsync(
-                            It.Is<FeedProcessing.ChangeFeedObserverContext>(context => context.PartitionKeyRangeId == processorSettings.PartitionKeyRangeId),
+                            It.Is<ChangeFeedObserverContext>(context => context.PartitionKeyRangeId == processorSettings.PartitionKeyRangeId),
                             It.Is<IReadOnlyList<Document>>(list => list.SequenceEqual(documents)), 
                             It.IsAny<CancellationToken>()),
                     Times.Once);

--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/FeedProcessor/AutoCheckPointTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/FeedProcessor/AutoCheckPointTests.cs
@@ -2,23 +2,23 @@
 // Copyright (c) Microsoft Corporation.  Licensed under the MIT license.
 //----------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions;
-using Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing;
-using Microsoft.Azure.Documents.Client;
-using Moq;
-using Xunit;
-
 namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.FeedProcessor
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing;
+    using Microsoft.Azure.Documents.Client;
+    using Moq;
+    using Xunit;
+
     [Trait("Category", "Gated")]
     public class AutoCheckPointTests
     {
-        private readonly FeedProcessing.IChangeFeedObserver changeFeedObserver;
+        private readonly IChangeFeedObserver changeFeedObserver;
         private readonly IChangeFeedObserverContext observerContext;
         private readonly CheckpointFrequency checkpointFrequency;
         private readonly AutoCheckpointer sut;
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.FeedProcessor
 
         public AutoCheckPointTests()
         {
-            changeFeedObserver = Mock.Of<FeedProcessing.IChangeFeedObserver>();
+            changeFeedObserver = Mock.Of<IChangeFeedObserver>();
             partitionCheckpointer = Mock.Of<IPartitionCheckpointer>();
             Mock.Get(partitionCheckpointer)
                 .Setup(checkPointer => checkPointer.CheckpointPartitionAsync(It.IsAny<string>()))

--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/FeedProcessor/PartitionChainingTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/FeedProcessor/PartitionChainingTests.cs
@@ -2,19 +2,19 @@
 // Copyright (c) Microsoft Corporation.  Licensed under the MIT license.
 //----------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Azure.Documents.ChangeFeedProcessor.DataAccess;
-using Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing;
-using Microsoft.Azure.Documents.Client;
-using Moq;
-using Xunit;
-
 namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.FeedProcessor
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor.DataAccess;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing;
+    using Microsoft.Azure.Documents.Client;
+    using Moq;
+    using Xunit;
+
     [Trait("Category", "Gated")]
     public class PartitionChainingTests
     {
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.FeedProcessor
         private readonly IChangeFeedDocumentClient docClient;
         private readonly IChangeFeedDocumentQuery<Document> documentQuery;
         private readonly IFeedResponse<Document> feedResponse1, feedResponse2;
-        private readonly FeedProcessing.IChangeFeedObserver observer;
+        private readonly IChangeFeedObserver observer;
         private readonly List<Document> batch1, batch2;
 
         public PartitionChainingTests()
@@ -82,14 +82,14 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.FeedProcessor
                 .Setup(ex => ex.CreateDocumentChangeFeedQuery(processorSettings.CollectionSelfLink, It.IsAny<ChangeFeedOptions>()))
                 .Returns(documentQuery);
 
-            observer = Mock.Of<FeedProcessing.IChangeFeedObserver>();
+            observer = Mock.Of<IChangeFeedObserver>();
             var checkPointer = new Mock<IPartitionCheckpointer>();
             partitionProcessor = new PartitionProcessor(observer, docClient, processorSettings, checkPointer.Object);
 
             var i = 0;
             Mock.Get(observer)
                 .Setup(feedObserver => feedObserver
-                    .ProcessChangesAsync(It.IsAny<FeedProcessing.ChangeFeedObserverContext>(), It.IsAny<IReadOnlyList<Document>>(), It.IsAny<CancellationToken>()))
+                    .ProcessChangesAsync(It.IsAny<ChangeFeedObserverContext>(), It.IsAny<IReadOnlyList<Document>>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(false))
                 .Callback(() =>
                 {
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.FeedProcessor
             Mock.Get(observer)
                 .Verify(feedObserver => feedObserver
                         .ProcessChangesAsync(
-                            It.Is<FeedProcessing.ChangeFeedObserverContext>(context => context.PartitionKeyRangeId == processorSettings.PartitionKeyRangeId),
+                            It.Is<ChangeFeedObserverContext>(context => context.PartitionKeyRangeId == processorSettings.PartitionKeyRangeId),
                             It.Is<IReadOnlyList<Document>>(list => list.SequenceEqual(batch1)),
                             It.IsAny<CancellationToken>()),
                     Times.Once);
@@ -117,14 +117,14 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.FeedProcessor
             Mock.Get(observer)
                 .Verify(feedObserver => feedObserver
                         .ProcessChangesAsync(
-                            It.Is<FeedProcessing.ChangeFeedObserverContext>(context => context.PartitionKeyRangeId == processorSettings.PartitionKeyRangeId),
+                            It.Is<ChangeFeedObserverContext>(context => context.PartitionKeyRangeId == processorSettings.PartitionKeyRangeId),
                             It.Is<IReadOnlyList<Document>>(list => list.SequenceEqual(batch2)),
                             It.IsAny<CancellationToken>()),
                     Times.Once);
 
             Mock.Get(observer)
                 .Verify(feedObserver => feedObserver
-                        .ProcessChangesAsync(It.IsAny<FeedProcessing.ChangeFeedObserverContext>(), It.IsAny<IReadOnlyList<Document>>(), It.IsAny<CancellationToken>()),
+                        .ProcessChangesAsync(It.IsAny<ChangeFeedObserverContext>(), It.IsAny<IReadOnlyList<Document>>(), It.IsAny<CancellationToken>()),
                     Times.Exactly(2));
         }
     }

--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/FeedProcessor/PartitionProcessorTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/FeedProcessor/PartitionProcessorTests.cs
@@ -2,20 +2,20 @@
 // Copyright (c) Microsoft Corporation.  Licensed under the MIT license.
 //----------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Azure.Documents.ChangeFeedProcessor.DataAccess;
-using Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing;
-using Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.Utils;
-using Microsoft.Azure.Documents.Client;
-using Moq;
-using Xunit;
-
 namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.FeedProcessor
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor.DataAccess;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.Utils;
+    using Microsoft.Azure.Documents.Client;
+    using Moq;
+    using Xunit;
+
     [Trait("Category", "Gated")]
     public class PartitionProcessorTests
     {
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.FeedProcessor
         private readonly IChangeFeedDocumentClient docClient;
         private readonly IChangeFeedDocumentQuery<Document> documentQuery;
         private readonly IFeedResponse<Document> feedResponse;
-        private readonly FeedProcessing.IChangeFeedObserver observer;
+        private readonly IChangeFeedObserver observer;
         private readonly List<Document> documents;
 
         public PartitionProcessorTests()
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.FeedProcessor
                 .Setup(ex => ex.CreateDocumentChangeFeedQuery(processorSettings.CollectionSelfLink, It.IsAny<ChangeFeedOptions>()))
                 .Returns(documentQuery);
 
-            observer = Mock.Of<FeedProcessing.IChangeFeedObserver>();
+            observer = Mock.Of<IChangeFeedObserver>();
             var checkPointer = new Mock<IPartitionCheckpointer>();
             sut = new PartitionProcessor(observer, docClient, processorSettings, checkPointer.Object);
         }
@@ -240,7 +240,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.FeedProcessor
             Mock.Get(observer)
                 .Verify(feedObserver => feedObserver
                         .ProcessChangesAsync(
-                            It.Is<FeedProcessing.ChangeFeedObserverContext>(context => context.PartitionKeyRangeId == processorSettings.PartitionKeyRangeId),
+                            It.Is<ChangeFeedObserverContext>(context => context.PartitionKeyRangeId == processorSettings.PartitionKeyRangeId),
                             It.Is<IReadOnlyList<Document>>(
                                 list => list.Count == 1 ? list.SequenceEqual(documents) :
                                         list.Count == 2 ? list.SequenceEqual(documents2) :

--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/PartitionManagement/PartitionControllerSplitTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/PartitionManagement/PartitionControllerSplitTests.cs
@@ -2,17 +2,17 @@
 // Copyright (c) Microsoft Corporation.  Licensed under the MIT license.
 //----------------------------------------------------------------
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions;
-using Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing;
-using Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement;
-using Moq;
-using Xunit;
-
 namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.PartitionManagement
 {
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement;
+    using Moq;
+    using Xunit;
+
     [Trait("Category", "Gated")]
     public class PartitionControllerSplitTests : IAsyncLifetime
     {
@@ -235,10 +235,10 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.PartitionManag
             return mock.Object;
         }
 
-        private static FeedProcessing.IChangeFeedObserver MockObserver()
+        private static IChangeFeedObserver MockObserver()
         {
-            var mock = new Mock<FeedProcessing.IChangeFeedObserver>();
-            mock.Setup(observer => observer.OpenAsync(It.IsAny<FeedProcessing.ChangeFeedObserverContext>()))
+            var mock = new Mock<IChangeFeedObserver>();
+            mock.Setup(observer => observer.OpenAsync(It.IsAny<ChangeFeedObserverContext>()))
                 .Returns(Task.FromResult(false));
             return mock.Object;
         }

--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/PartitionManagement/PartitionControllerTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/PartitionManagement/PartitionControllerTests.cs
@@ -2,16 +2,16 @@
 // Copyright (c) Microsoft Corporation.  Licensed under the MIT license.
 //----------------------------------------------------------------
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing;
-using Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement;
-using Moq;
-using Xunit;
-
 namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.PartitionManagement
 {
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement;
+    using Moq;
+    using Xunit;
+
     [Trait("Category", "Gated")]
     public class PartitionControllerTests : IAsyncLifetime
     {
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.PartitionManag
         private readonly ILeaseManager leaseManager;
         private readonly IPartitionProcessor partitionProcessor;
         private readonly ILeaseRenewer leaseRenewer;
-        private readonly FeedProcessing.IChangeFeedObserver observer;
+        private readonly IChangeFeedObserver observer;
         private readonly IPartitionSynchronizer synchronizer;
         private readonly PartitionController sut;
         private readonly IPartitionSupervisorFactory partitionSupervisorFactory;
@@ -263,9 +263,9 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.PartitionManag
             return mock.Object;
         }
 
-        private static FeedProcessing.IChangeFeedObserver MockObserver()
+        private static IChangeFeedObserver MockObserver()
         {
-            var mock = new Mock<FeedProcessing.IChangeFeedObserver>();
+            var mock = new Mock<IChangeFeedObserver>();
             return mock.Object;
         }
 

--- a/src/DocumentDB.ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
@@ -22,22 +22,21 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor
     /// <example>
     /// <code language="C#">
     /// <![CDATA[
-    /// using Microsoft.Azure.Documents;
-    /// using Microsoft.Azure.Documents.ChangeFeedProcessor;
-    /// using System;
-    /// using System.Collections.Generic;
-    /// using System.Threading;
-    /// using System.Threading.Tasks;
-    ///
+    /// // Observer.cs
     /// namespace Sample
     /// {
+    ///     using System;
+    ///     using System.Collections.Generic;
+    ///     using System.Threading;
+    ///     using System.Threading.Tasks;
+    ///     using Microsoft.Azure.Documents;
     ///     using Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing;
     ///
     ///     class SampleObserver : IChangeFeedObserver
     ///     {
     ///         public Task CloseAsync(IChangeFeedObserverContext context, ChangeFeedObserverCloseReason reason)
     ///         {
-    ///             return Task.CompletedTask;  ///  Note: requires targeting .Net 4.6+.
+    ///             return Task.CompletedTask;  // Note: requires targeting .Net 4.6+.
     ///         }
     ///
     ///         public Task OpenAsync(IChangeFeedObserverContext context)
@@ -51,6 +50,15 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor
     ///             return Task.CompletedTask;
     ///         }
     ///     }
+    /// }
+    ///
+    /// // Main.cs
+    /// namespace Sample
+    /// {
+    ///     using System;
+    ///     using System.Threading.Tasks;
+    ///     using Microsoft.Azure.Documents.ChangeFeedProcessor;
+    ///     using Microsoft.Azure.Documents.ChangeFeedProcessor.Logging;
     ///
     ///     class ChangeFeedProcessorSample
     ///     {

--- a/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/ChangeFeedObserverCloseReason.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/ChangeFeedObserverCloseReason.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft Corporation.  Licensed under the MIT license.
 //----------------------------------------------------------------
 
-namespace Microsoft.Azure.Documents.ChangeFeedProcessor
+namespace Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing
 {
     /// <summary>
     /// The reason for the <see cref="IChangeFeedObserver"/> to close.

--- a/src/DocumentDB.ChangeFeedProcessor/Obsolete/Adapters/ChangeFeedObserverAdapter.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Obsolete/Adapters/ChangeFeedObserverAdapter.cs
@@ -26,9 +26,11 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Obsolete.Adapters
             return this.observer.OpenAsync(new ChangeFeedObserverContextAdapter(context));
         }
 
-        public Task CloseAsync(FeedProcessing.IChangeFeedObserverContext context, ChangeFeedObserverCloseReason reason)
+        public Task CloseAsync(FeedProcessing.IChangeFeedObserverContext context, FeedProcessing.ChangeFeedObserverCloseReason reason)
         {
-            return this.observer.CloseAsync(new ChangeFeedObserverContextAdapter(context), reason);
+#pragma warning disable CS0618 // Type or member is obsolete
+            return this.observer.CloseAsync(new ChangeFeedObserverContextAdapter(context), (ChangeFeedObserverCloseReason)reason);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         public Task ProcessChangesAsync(FeedProcessing.IChangeFeedObserverContext context, IReadOnlyList<Document> docs, CancellationToken cancellationToken)
@@ -55,9 +57,11 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Obsolete.Adapters
             return this.observer.OpenAsync(new ChangeFeedObserverContextAdapter(context));
         }
 
-        public Task CloseAsync(FeedProcessing.IChangeFeedObserverContext context, ChangeFeedObserverCloseReason reason)
+        public Task CloseAsync(FeedProcessing.IChangeFeedObserverContext context, FeedProcessing.ChangeFeedObserverCloseReason reason)
         {
-            return this.observer.CloseAsync(new ChangeFeedObserverContextAdapter(context), reason);
+#pragma warning disable CS0618 // Type or member is obsolete
+            return this.observer.CloseAsync(new ChangeFeedObserverContextAdapter(context), (ChangeFeedObserverCloseReason)reason);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         public Task ProcessChangesAsync(FeedProcessing.IChangeFeedObserverContext context, IReadOnlyList<Document> docs, CancellationToken cancellationToken)

--- a/src/DocumentDB.ChangeFeedProcessor/Obsolete/ChangeFeedObserverCloseReason.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Obsolete/ChangeFeedObserverCloseReason.cs
@@ -1,0 +1,45 @@
+﻿//----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  Licensed under the MIT license.
+//----------------------------------------------------------------
+
+namespace Microsoft.Azure.Documents.ChangeFeedProcessor
+{
+    using System;
+
+    /// <summary>
+    /// The reason for the <see cref="IChangeFeedObserver"/> to close.
+    /// </summary>
+    [Obsolete("Switch to the ChangeFeedProcessorBuilder for building the change feed processor and use new enum Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing.ChangeFeedObserverCloseReason.")]
+    public enum ChangeFeedObserverCloseReason
+    {
+        /// <summary>
+        /// Unknown failure. This should never be sent to observers.
+        /// </summary>
+        Unknown = 0,
+
+        /// <summary>
+        /// The ChangeFeedEventHost is shutting down.
+        /// </summary>
+        Shutdown,
+
+        /// <summary>
+        /// The resource, such as database or collection was removed.
+        /// </summary>
+        ResourceGone,
+
+        /// <summary>
+        /// Lease was lost due to expiration or load-balancing.
+        /// </summary>
+        LeaseLost,
+
+        /// <summary>
+        /// IChangeFeedObserver threw an exception.
+        /// </summary>
+        ObserverError,
+
+        /// <summary>
+        /// The lease is gone. This can be due to partition split.
+        /// </summary>
+        LeaseGone,
+    }
+}

--- a/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/PartitionSupervisor.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/PartitionSupervisor.cs
@@ -14,13 +14,13 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement
     internal class PartitionSupervisor : IPartitionSupervisor
     {
         private readonly ILease lease;
-        private readonly FeedProcessing.IChangeFeedObserver observer;
+        private readonly IChangeFeedObserver observer;
         private readonly IPartitionProcessor processor;
         private readonly ILeaseRenewer renewer;
         private readonly CancellationTokenSource renewerCancellation = new CancellationTokenSource();
         private CancellationTokenSource processorCancellation;
 
-        public PartitionSupervisor(ILease lease, FeedProcessing.IChangeFeedObserver observer, IPartitionProcessor processor, ILeaseRenewer renewer)
+        public PartitionSupervisor(ILease lease, IChangeFeedObserver observer, IPartitionProcessor processor, ILeaseRenewer renewer)
         {
             this.lease = lease;
             this.observer = observer;
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement
 
         public async Task RunAsync(CancellationToken shutdownToken)
         {
-            var context = new FeedProcessing.ChangeFeedObserverContext(this.lease.PartitionId);
+            var context = new ChangeFeedObserverContext(this.lease.PartitionId);
             await this.observer.OpenAsync(context).ConfigureAwait(false);
 
             this.processorCancellation = CancellationTokenSource.CreateLinkedTokenSource(shutdownToken);

--- a/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/PartitionSupervisorFactory.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/PartitionSupervisorFactory.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement
 
     internal class PartitionSupervisorFactory : IPartitionSupervisorFactory
     {
-        private readonly FeedProcessing.IChangeFeedObserverFactory observerFactory;
+        private readonly IChangeFeedObserverFactory observerFactory;
         private readonly IChangeFeedDocumentClient documentClient;
         private readonly string collectionSelfLink;
         private readonly ILeaseManager leaseManager;
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement
         private readonly ChangeFeedOptions changeFeedOptions;
 
         public PartitionSupervisorFactory(
-            FeedProcessing.IChangeFeedObserverFactory observerFactory,
+            IChangeFeedObserverFactory observerFactory,
             IChangeFeedDocumentClient documentClient,
             string collectionSelfLink,
             ILeaseManager leaseManager,
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement
             };
 
             var checkpointer = new PartitionCheckpointer(this.leaseManager, lease);
-            FeedProcessing.IChangeFeedObserver changeFeedObserver = this.observerFactory.CreateObserver();
+            IChangeFeedObserver changeFeedObserver = this.observerFactory.CreateObserver();
             var processor = new PartitionProcessor(changeFeedObserver, this.documentClient, processorSettings, checkpointer);
             var renewer = new LeaseRenewer(lease, this.leaseManager, this.changeFeedHostOptions.LeaseRenewInterval);
 


### PR DESCRIPTION
…lve namespace clash in user's observer code. With this change, for observer code the user can do just using the FeedProcessing namespace, no need to include the parent namespace.