### PR TITLE
Make ChangeFeedProcessorOptions.RequestContinuation internal -- not visible for new API, …

### DIFF
--- a/src/DocumentDB.ChangeFeedProcessor/ChangeFeedProcessorOptions.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/ChangeFeedProcessorOptions.cs
@@ -109,14 +109,14 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor
         }
 
         /// <summary>
-        /// Gets or sets the request continuation token in the Azure Cosmos DB service.
-        /// </summary>
-        public string RequestContinuation { get; set; }
-
-        /// <summary>
         /// Gets or sets the session token for use with session consistency in the Azure Cosmos DB service.
         /// </summary>
         public string SessionToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets the request continuation token in the Azure Cosmos DB service.
+        /// </summary>
+        internal string RequestContinuation { get; set; }
 
         /// <summary>
         /// Gets or sets the minimum partition count for the host.

--- a/src/DocumentDB.ChangeFeedProcessor/DocumentDB.ChangeFeedProcessor.csproj
+++ b/src/DocumentDB.ChangeFeedProcessor/DocumentDB.ChangeFeedProcessor.csproj
@@ -46,7 +46,7 @@
     <Version>2.0.1</Version>
     <AssemblyVersion>2.0.1.0</AssemblyVersion>
     <FileVersion>2.0.1.0</FileVersion>
-    <PackageReleaseNotes>The change log for this project is made available at https://docs.microsoft.com/en-us/azure/cosmos-db/sql-api-sdk-dotnet-changefeed at the time of release.
+    <PackageReleaseNotes>The change log for this project is available at https://docs.microsoft.com/azure/cosmos-db/sql-api-sdk-dotnet-changefeed.
 </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/src/DocumentDB.ChangeFeedProcessor/DocumentDB.ChangeFeedProcessor.csproj
+++ b/src/DocumentDB.ChangeFeedProcessor/DocumentDB.ChangeFeedProcessor.csproj
@@ -43,7 +43,11 @@
     <!--CS1587:XML comment is not placed on a valid language element 
     LibLog files have misplaced comments, but we cannot touch them.-->
     <NoWarn>1587</NoWarn>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
+    <AssemblyVersion>2.0.1.0</AssemblyVersion>
+    <FileVersion>2.0.1.0</FileVersion>
+    <PackageReleaseNotes>The change log for this project is made available at https://docs.microsoft.com/en-us/azure/cosmos-db/sql-api-sdk-dotnet-changefeed at the time of release.
+</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
…but still keep for legacy. Also add link to release notes to the package metadata.