### PR TITLE
Estimator to return 1 when there are no leases

### DIFF
--- a/src/DocumentDB.ChangeFeedProcessor.IntegrationTests/EstimatorTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.IntegrationTests/EstimatorTests.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.IntegrationTests
         [Fact]
         public async Task CountPendingDocuments()
         {
+            // Cleanup the test collection to avoid other tests' documents causing issues with StartFromBeginning
+            await this.ResetTestCollection();
             int documentCount = 1;
             int partitionCount = await IntegrationTestsHelper.GetPartitionCount(this.ClassData.monitoredCollectionInfo);
             int openedCount = 0, processedCount = 0;
@@ -130,6 +132,8 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.IntegrationTests
         [Fact]
         public async Task WhenNoLeasesExistReturn1()
         {
+            // Cleanup the test collection to avoid other tests' documents causing issues with StartFromBeginning
+            await this.ResetTestCollection();
             var hostName = Guid.NewGuid().ToString();
 
             var host = new ChangeFeedEventHost(
@@ -144,9 +148,65 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.IntegrationTests
             Assert.Equal(1, estimation);
         }
 
+        /// <summary>
+        /// This test checks that when the ContinuationToken is null, we send the StartFromBeginning flag, but since there is no documents, it returns 0
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task WhenLeasesHaveContinuationTokenNullReturn0()
+        {
+            // Cleanup the test collection to avoid other tests' documents causing issues with StartFromBeginning
+            await this.ResetTestCollection();
+            int documentCount = 1;
+            int partitionCount = await IntegrationTestsHelper.GetPartitionCount(this.ClassData.monitoredCollectionInfo);
+            int openedCount = 0, processedCount = 0;
+            var allObserversStarted = new ManualResetEvent(false);
+            var allDocsProcessed = new ManualResetEvent(false);
+
+            var observerFactory = new TestObserverFactory(
+                context =>
+                {
+                    int newCount = Interlocked.Increment(ref openedCount);
+                    if (newCount == partitionCount) allObserversStarted.Set();
+                    return Task.CompletedTask;
+                },
+                null,
+                (ChangeFeedObserverContext context, IReadOnlyList<Document> docs) =>
+                {
+                    int newCount = Interlocked.Add(ref processedCount, docs.Count);
+                    if (newCount == documentCount) allDocsProcessed.Set();
+                    return Task.CompletedTask;
+                });
+
+            var hostName = Guid.NewGuid().ToString();
+
+            // We create a host to initialize the leases with ContinuationToken null
+            var host = new ChangeFeedEventHost(
+                hostName,
+                this.ClassData.monitoredCollectionInfo,
+                this.LeaseCollectionInfo,
+                new ChangeFeedOptions { StartFromBeginning = false },
+                new ChangeFeedHostOptions());
+
+            // Initialize leases
+            await host.RegisterObserverFactoryAsync(observerFactory);
+            // Stop host, this leaves the leases with ContinuationToken null state
+            await host.UnregisterObserversAsync();
+
+            // Since the leases have ContinuationToken null state, the estimator will use StartFromBeginning and pick-up the changes that happened from the start
+            long estimation = await host.GetEstimatedRemainingWork();
+            Assert.Equal(0, estimation);
+        }
+
+        /// <summary>
+        /// This test checks that when the ContinuationToken is null, it then inserts 10 document, and since we send the StartFromBeginning flag, the expected value is 10
+        /// </summary>
+        /// <returns></returns>
         [Fact]
         public async Task WhenLeasesHaveContinuationTokenNullStartFromBeginning()
         {
+            // Cleanup the test collection to avoid other tests' documents causing issues with StartFromBeginning
+            await this.ResetTestCollection();
             int documentCount = 1;
             int partitionCount = await IntegrationTestsHelper.GetPartitionCount(this.ClassData.monitoredCollectionInfo);
             int openedCount = 0, processedCount = 0;

--- a/src/DocumentDB.ChangeFeedProcessor.IntegrationTests/IntegrationTest.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.IntegrationTests/IntegrationTest.cs
@@ -182,6 +182,16 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.IntegrationTests
             }
         }
 
+        /// <summary>
+        /// Recreates the test collection
+        /// </summary>
+        /// <returns></returns>
+        public async Task ResetTestCollection()
+        {
+            await IntegrationTest.TestClassCleanupAsync(this);
+            await IntegrationTest.TestClassInitializeAsync(this, $"data_{this.GetType().Name}");
+        }
+
         protected virtual Task FinishTestClassInitializeAsync()
         {
             return Task.CompletedTask;

--- a/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/RemainingWorkEstimator.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/RemainingWorkEstimator.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement
                 hasAtLeastOneLease = true;
                 options.PartitionKeyRangeId = existingLease.PartitionId;
                 options.RequestContinuation = existingLease.ContinuationToken;
+                options.StartFromBeginning = string.IsNullOrEmpty(existingLease.ContinuationToken);
 
                 IChangeFeedDocumentQuery<Document> query = this.feedDocumentClient.CreateDocumentChangeFeedQuery(this.collectionSelfLink, options);
                 IFeedResponse<Document> response = null;


### PR DESCRIPTION
This PR will make the `GetEstimatedRemainingWork` return 1 instead of 0 if there are no leases initialized.