### PR TITLE
Make LeaseLostException, PartitionNotFoundException, and PartitionSplitException public

### DIFF
--- a/src/DocumentDB.ChangeFeedProcessor/Exceptions/LeaseLostException.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Exceptions/LeaseLostException.cs
@@ -8,19 +8,34 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
     using System.Runtime.Serialization;
     using Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement;
 
+    /// <summary>
+    /// Exception occurred when lease was taken by a different host.
+    /// </summary>
     [Serializable]
-    internal class LeaseLostException : Exception
+    public class LeaseLostException : Exception
     {
-        /// <summary>Initializes a new instance of the <see cref="LeaseLostException" /> class using default values.</summary>
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LeaseLostException" /> class using default values.
+        /// </summary>
         public LeaseLostException()
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LeaseLostException" /> class using default values.
+        /// </summary>
+        /// <param name="lease">Instance of a lease that was taken by a different host.</param>
         public LeaseLostException(ILease lease)
         {
             this.Lease = lease;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LeaseLostException" /> class using default values.
+        /// </summary>
+        /// <param name="lease">Instance of a lease that was taken by a different host.</param>
+        /// <param name="innerException">The inner exception.</param>
+        /// <param name="isGone">Whether lease doesn't exist.</param>
         public LeaseLostException(ILease lease, Exception innerException, bool isGone = false)
             : base(null, innerException)
         {
@@ -28,26 +43,51 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
             this.IsGone = isGone;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LeaseLostException" /> class using default values.
+        /// </summary>
+        /// <param name="message">The exception error message.</param>
         public LeaseLostException(string message)
             : base(message)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LeaseLostException" /> class using default values.
+        /// </summary>
+        /// <param name="message">The exception error message.</param>
+        /// <param name="innerException">The inner exception.</param>
         public LeaseLostException(string message, Exception innerException)
             : base(message, innerException)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LeaseLostException" /> class using default values.
+        /// </summary>
+        /// <param name="info">The SerializationInfo object that holds serialized object data for the exception being thrown.</param>
+        /// <param name="context">The StreamingContext that contains contextual information about the source or destination.</param>
         protected LeaseLostException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
             this.Lease = (ILease)info.GetValue("Lease", typeof(ILease));
         }
 
+        /// <summary>
+        /// Gets lease that was taken by a different host.
+        /// </summary>
         public ILease Lease { get; }
 
+        /// <summary>
+        /// Gets a value indicating whether lease doesn't exist.
+        /// </summary>
         public bool IsGone { get; }
 
+        /// <summary>
+        /// Sets the System.Runtime.Serialization.SerializationInfo with information about the exception.
+        /// </summary>
+        /// <param name="info">The SerializationInfo object that holds serialized object data for the exception being thrown.</param>
+        /// <param name="context">The StreamingContext that contains contextual information about the source or destination.</param>
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);

--- a/src/DocumentDB.ChangeFeedProcessor/Exceptions/LeaseLostException.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Exceptions/LeaseLostException.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
         }
 
         /// <summary>
-        /// Gets lost lease.
+        /// Gets the lost lease.
         /// </summary>
         public ILease Lease { get; }
 

--- a/src/DocumentDB.ChangeFeedProcessor/Exceptions/LeaseLostException.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Exceptions/LeaseLostException.cs
@@ -15,14 +15,14 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
     public class LeaseLostException : Exception
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="LeaseLostException" /> class using default values.
+        /// Initializes a new instance of the <see cref="LeaseLostException" /> class.
         /// </summary>
         public LeaseLostException()
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="LeaseLostException" /> class using default values.
+        /// Initializes a new instance of the <see cref="LeaseLostException" /> class using the specified lease.
         /// </summary>
         /// <param name="lease">Instance of a lost lease.</param>
         public LeaseLostException(ILease lease)
@@ -31,12 +31,12 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="LeaseLostException" /> class using default values.
+        /// Initializes a new instance of the <see cref="LeaseLostException" /> class using the specified lease, inner exception, and a flag indicating whether lease is gone.
         /// </summary>
         /// <param name="lease">Instance of a lost lease.</param>
         /// <param name="innerException">The inner exception.</param>
         /// <param name="isGone">Whether lease doesn't exist.</param>
-        public LeaseLostException(ILease lease, Exception innerException, bool isGone = false)
+        public LeaseLostException(ILease lease, Exception innerException, bool isGone)
             : base(null, innerException)
         {
             this.Lease = lease;
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="LeaseLostException" /> class using default values.
+        /// Initializes a new instance of the <see cref="LeaseLostException" /> class using error message.
         /// </summary>
         /// <param name="message">The exception error message.</param>
         public LeaseLostException(string message)
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="LeaseLostException" /> class using default values.
+        /// Initializes a new instance of the <see cref="LeaseLostException" /> class using error message and inner exception.
         /// </summary>
         /// <param name="message">The exception error message.</param>
         /// <param name="innerException">The inner exception.</param>

--- a/src/DocumentDB.ChangeFeedProcessor/Exceptions/LeaseLostException.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Exceptions/LeaseLostException.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
     using Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement;
 
     /// <summary>
-    /// Exception occurred when lease was taken by a different host.
+    /// Exception occurred when lease is lost, that would typically happen when it is taken by another host. Other cases: communication failure, number of retries reached, lease not found.
     /// </summary>
     [Serializable]
     public class LeaseLostException : Exception
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
         /// <summary>
         /// Initializes a new instance of the <see cref="LeaseLostException" /> class using default values.
         /// </summary>
-        /// <param name="lease">Instance of a lease that was taken by a different host.</param>
+        /// <param name="lease">Instance of a lost lease.</param>
         public LeaseLostException(ILease lease)
         {
             this.Lease = lease;
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
         /// <summary>
         /// Initializes a new instance of the <see cref="LeaseLostException" /> class using default values.
         /// </summary>
-        /// <param name="lease">Instance of a lease that was taken by a different host.</param>
+        /// <param name="lease">Instance of a lost lease.</param>
         /// <param name="innerException">The inner exception.</param>
         /// <param name="isGone">Whether lease doesn't exist.</param>
         public LeaseLostException(ILease lease, Exception innerException, bool isGone = false)
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
         }
 
         /// <summary>
-        /// Gets lease that was taken by a different host.
+        /// Gets lost lease.
         /// </summary>
         public ILease Lease { get; }
 

--- a/src/DocumentDB.ChangeFeedProcessor/Exceptions/PartitionException.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Exceptions/PartitionException.cs
@@ -6,13 +6,23 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
 {
     using System;
 
-    internal class PartitionException : Exception
+    /// <summary>
+    /// General exception occurred during partition processing.
+    /// </summary>
+    public class PartitionException : Exception
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PartitionException"/> class.
+        /// </summary>
+        /// <param name="lastContinuation"> Request continuation token </param>
         public PartitionException(string lastContinuation)
         {
             this.LastContinuation = lastContinuation;
         }
 
+        /// <summary>
+        /// Gets value of request continuation token.
+        /// </summary>
         public string LastContinuation { get; }
     }
 }

--- a/src/DocumentDB.ChangeFeedProcessor/Exceptions/PartitionException.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Exceptions/PartitionException.cs
@@ -5,6 +5,7 @@
 namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
 {
     using System;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// General exception occurred during partition processing.
@@ -12,12 +13,39 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
     public class PartitionException : Exception
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="PartitionException" /> class.
+        /// </summary>
+        public PartitionException()
+        {
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="PartitionException"/> class.
         /// </summary>
         /// <param name="lastContinuation"> Request continuation token </param>
         public PartitionException(string lastContinuation)
         {
             this.LastContinuation = lastContinuation;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PartitionException" /> class using error message and inner exception.
+        /// </summary>
+        /// <param name="message">The exception error message.</param>
+        /// <param name="innerException">The inner exception.</param>
+        public PartitionException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PartitionException" /> class using default values.
+        /// </summary>
+        /// <param name="info">The SerializationInfo object that holds serialized object data for the exception being thrown.</param>
+        /// <param name="context">The StreamingContext that contains contextual information about the source or destination.</param>
+        protected PartitionException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
         }
 
         /// <summary>

--- a/src/DocumentDB.ChangeFeedProcessor/Exceptions/PartitionException.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Exceptions/PartitionException.cs
@@ -15,15 +15,26 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
         /// <summary>
         /// Initializes a new instance of the <see cref="PartitionException" /> class.
         /// </summary>
-        public PartitionException()
+        protected PartitionException()
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PartitionException"/> class.
+        /// Initializes a new instance of the <see cref="PartitionException"/> class using error message.
         /// </summary>
+        /// <param name="message">The exception error message.</param>
+        protected PartitionException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PartitionException"/> class using error message and last continuation token.
+        /// </summary>
+        /// <param name="message">The exception error message.</param>
         /// <param name="lastContinuation"> Request continuation token </param>
-        public PartitionException(string lastContinuation)
+        protected PartitionException(string message, string lastContinuation)
+            : base(message)
         {
             this.LastContinuation = lastContinuation;
         }
@@ -33,7 +44,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
         /// </summary>
         /// <param name="message">The exception error message.</param>
         /// <param name="innerException">The inner exception.</param>
-        public PartitionException(string message, Exception innerException)
+        protected PartitionException(string message, Exception innerException)
             : base(message, innerException)
         {
         }
@@ -49,7 +60,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
         }
 
         /// <summary>
-        /// Gets value of request continuation token.
+        /// Gets the value of request continuation token.
         /// </summary>
         public string LastContinuation { get; }
     }

--- a/src/DocumentDB.ChangeFeedProcessor/Exceptions/PartitionNotFoundException.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Exceptions/PartitionNotFoundException.cs
@@ -20,11 +20,21 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PartitionNotFoundException"/> class.
+        /// Initializes a new instance of the <see cref="PartitionNotFoundException"/> class using error message.
         /// </summary>
-        /// <param name="lastContinuation"> Request continuation token </param>
-        public PartitionNotFoundException(string lastContinuation)
-            : base(lastContinuation)
+        /// <param name="message">The exception error message.</param>
+        public PartitionNotFoundException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PartitionNotFoundException"/> class using error message and last continuation token.
+        /// </summary>
+        /// <param name="message">The exception error message.</param>
+        /// <param name="lastContinuation"> Request continuation token.</param>
+        public PartitionNotFoundException(string message, string lastContinuation)
+            : base(message, lastContinuation)
         {
         }
 

--- a/src/DocumentDB.ChangeFeedProcessor/Exceptions/PartitionNotFoundException.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Exceptions/PartitionNotFoundException.cs
@@ -4,17 +4,47 @@
 
 namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
 {
+    using System;
+    using System.Runtime.Serialization;
+
     /// <summary>
     /// Exception occurred when partition wasn't found.
     /// </summary>
     public class PartitionNotFoundException : PartitionException
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="PartitionNotFoundException" /> class.
+        /// </summary>
+        public PartitionNotFoundException()
+        {
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="PartitionNotFoundException"/> class.
         /// </summary>
         /// <param name="lastContinuation"> Request continuation token </param>
         public PartitionNotFoundException(string lastContinuation)
             : base(lastContinuation)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PartitionNotFoundException" /> class using error message and inner exception.
+        /// </summary>
+        /// <param name="message">The exception error message.</param>
+        /// <param name="innerException">The inner exception.</param>
+        public PartitionNotFoundException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PartitionNotFoundException" /> class using default values.
+        /// </summary>
+        /// <param name="info">The SerializationInfo object that holds serialized object data for the exception being thrown.</param>
+        /// <param name="context">The StreamingContext that contains contextual information about the source or destination.</param>
+        protected PartitionNotFoundException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/src/DocumentDB.ChangeFeedProcessor/Exceptions/PartitionNotFoundException.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Exceptions/PartitionNotFoundException.cs
@@ -4,8 +4,15 @@
 
 namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
 {
-    internal class PartitionNotFoundException : PartitionException
+    /// <summary>
+    /// Exception occurred when partition wasn't found.
+    /// </summary>
+    public class PartitionNotFoundException : PartitionException
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PartitionNotFoundException"/> class.
+        /// </summary>
+        /// <param name="lastContinuation"> Request continuation token </param>
         public PartitionNotFoundException(string lastContinuation)
             : base(lastContinuation)
         {

--- a/src/DocumentDB.ChangeFeedProcessor/Exceptions/PartitionSplitException.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Exceptions/PartitionSplitException.cs
@@ -4,8 +4,15 @@
 
 namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
 {
-    internal class PartitionSplitException : PartitionException
+    /// <summary>
+    /// Exception occurred during partition split.
+    /// </summary>
+    public class PartitionSplitException : PartitionException
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PartitionSplitException"/> class.
+        /// </summary>
+        /// <param name="lastContinuation"> Request continuation token </param>
         public PartitionSplitException(string lastContinuation)
             : base(lastContinuation)
         {

--- a/src/DocumentDB.ChangeFeedProcessor/Exceptions/PartitionSplitException.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Exceptions/PartitionSplitException.cs
@@ -4,17 +4,47 @@
 
 namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
 {
+    using System;
+    using System.Runtime.Serialization;
+
     /// <summary>
     /// Exception occurred during partition split.
     /// </summary>
     public class PartitionSplitException : PartitionException
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="PartitionSplitException" /> class.
+        /// </summary>
+        public PartitionSplitException()
+        {
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="PartitionSplitException"/> class.
         /// </summary>
         /// <param name="lastContinuation"> Request continuation token </param>
         public PartitionSplitException(string lastContinuation)
             : base(lastContinuation)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PartitionSplitException" /> class using error message and inner exception.
+        /// </summary>
+        /// <param name="message">The exception error message.</param>
+        /// <param name="innerException">The inner exception.</param>
+        public PartitionSplitException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PartitionSplitException" /> class using default values.
+        /// </summary>
+        /// <param name="info">The SerializationInfo object that holds serialized object data for the exception being thrown.</param>
+        /// <param name="context">The StreamingContext that contains contextual information about the source or destination.</param>
+        protected PartitionSplitException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/src/DocumentDB.ChangeFeedProcessor/Exceptions/PartitionSplitException.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Exceptions/PartitionSplitException.cs
@@ -20,11 +20,21 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PartitionSplitException"/> class.
+        /// Initializes a new instance of the <see cref="PartitionSplitException"/> class using error message.
         /// </summary>
-        /// <param name="lastContinuation"> Request continuation token </param>
-        public PartitionSplitException(string lastContinuation)
-            : base(lastContinuation)
+        /// <param name="message">The exception error message.</param>
+        public PartitionSplitException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PartitionSplitException"/> class using error message and last continuation token.
+        /// </summary>
+        /// <param name="message">The exception error message.</param>
+        /// <param name="lastContinuation"> Request continuation token.</param>
+        public PartitionSplitException(string message, string lastContinuation)
+            : base(message, lastContinuation)
         {
         }
 

--- a/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/PartitionProcessor.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/PartitionProcessor.cs
@@ -66,9 +66,9 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing
                     switch (docDbError)
                     {
                         case DocDbError.PartitionNotFound:
-                            throw new PartitionNotFoundException("partition not found", requestContinuation);
+                            throw new PartitionNotFoundException("Partition not found.", requestContinuation);
                         case DocDbError.PartitionSplit:
-                            throw new PartitionSplitException("partition split", requestContinuation);
+                            throw new PartitionSplitException("Partition split.", requestContinuation);
                         case DocDbError.Undefined:
                             throw;
                         case DocDbError.MaxItemCountTooLarge:

--- a/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/PartitionProcessor.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/PartitionProcessor.cs
@@ -66,9 +66,9 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing
                     switch (docDbError)
                     {
                         case DocDbError.PartitionNotFound:
-                            throw new PartitionNotFoundException(requestContinuation);
+                            throw new PartitionNotFoundException("partition not found", requestContinuation);
                         case DocDbError.PartitionSplit:
-                            throw new PartitionSplitException(requestContinuation);
+                            throw new PartitionSplitException("partition split", requestContinuation);
                         case DocDbError.Undefined:
                             throw;
                         case DocDbError.MaxItemCountTooLarge:


### PR DESCRIPTION
We need to make these exceptions public in order to be able for user to throw/catch them in a custom partition processing logic.