### PR TITLE
PartitionController didn't pass actual continuation token to the  syn…

### DIFF
--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/PartitionManagement/PartitionSynchronizerTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/PartitionManagement/PartitionSynchronizerTests.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.Documents.ChangeFeedProcessor.Bootstrapping;
+using Microsoft.Azure.Documents.ChangeFeedProcessor.DataAccess;
+using Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement;
+using Microsoft.Azure.Documents.Client;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.PartitionManagement
+{
+    [Trait("Category", "Gated")]
+    public class PartitionSynchronizerTests
+    {
+        [Fact]
+        public async Task SplitSplitPartitionAsync_ShouldReturnLeasesWithLastKnonwContinuation_IfHappyPath()
+        {
+            const string lastKnowToken = "last know token";
+
+            IEnumerable<PartitionKeyRange> keyRanges = new[]
+            {
+                new PartitionKeyRange
+                {
+                    Id = "20", Parents = new Collection<string>(new[] {"10"})
+                },
+                new PartitionKeyRange
+                {
+                    Id = "30", Parents = new Collection<string>(new[] {"10"})
+                }
+            };
+
+            var lease = Mock.Of<ILease>(l => l.PartitionId == "10" && l.ContinuationToken == "pre-last other token");
+
+            var keyRangeResponse = Mock.Of<IFeedResponse<PartitionKeyRange>>(r => r.GetEnumerator() == keyRanges.GetEnumerator());
+            IChangeFeedDocumentClient documentClient = Mock.Of<IChangeFeedDocumentClient>(c => c.ReadPartitionKeyRangeFeedAsync(It.IsAny<string>(), It.IsAny<FeedOptions>()) == Task.FromResult(keyRangeResponse));
+
+            var lease20 = Mock.Of<ILease>();
+            var lease30 = Mock.Of<ILease>();
+            ILeaseManager leaseManager = Mock.Of<ILeaseManager>(m => 
+                m.CreateLeaseIfNotExistAsync("20", lastKnowToken) == Task.FromResult(lease20) && 
+                m.CreateLeaseIfNotExistAsync("30", lastKnowToken) == Task.FromResult(lease30));
+
+            var sut = new PartitionSynchronizer(documentClient, "collectionlink", leaseManager, 1, int.MaxValue);
+            IEnumerable<ILease> result = await sut.SplitPartitionAsync(lease, lastKnowToken);
+            Assert.NotNull(result);
+            Assert.Equal(new [] { lease20, lease30 }, result);
+        }
+    }
+}

--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/PartitionManagement/PartitionSynchronizerTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/PartitionManagement/PartitionSynchronizerTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.PartitionManag
                 }
             };
 
-            var lease = Mock.Of<ILease>(l => l.PartitionId == "10" && l.ContinuationToken == "pre-last other token");
+            var lease = Mock.Of<ILease>(l => l.PartitionId == "10" && l.ContinuationToken == lastKnowToken);
 
             var keyRangeResponse = Mock.Of<IFeedResponse<PartitionKeyRange>>(r => r.GetEnumerator() == keyRanges.GetEnumerator());
             IChangeFeedDocumentClient documentClient = Mock.Of<IChangeFeedDocumentClient>(c => c.ReadPartitionKeyRangeFeedAsync(It.IsAny<string>(), It.IsAny<FeedOptions>()) == Task.FromResult(keyRangeResponse));
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.PartitionManag
                 m.CreateLeaseIfNotExistAsync("30", lastKnowToken) == Task.FromResult(lease30));
 
             var sut = new PartitionSynchronizer(documentClient, "collectionlink", leaseManager, 1, int.MaxValue);
-            IEnumerable<ILease> result = await sut.SplitPartitionAsync(lease, lastKnowToken);
+            IEnumerable<ILease> result = await sut.SplitPartitionAsync(lease);
             Assert.NotNull(result);
             Assert.Equal(new [] { lease20, lease30 }, result);
         }

--- a/src/DocumentDB.ChangeFeedProcessor/Bootstrapping/PartitionSynchronizer.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Bootstrapping/PartitionSynchronizer.cs
@@ -43,13 +43,12 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Bootstrapping
             await this.CreateLeasesAsync(partitionIds).ConfigureAwait(false);
         }
 
-        public async Task<IEnumerable<ILease>> SplitPartitionAsync(ILease lease)
+        public async Task<IEnumerable<ILease>> SplitPartitionAsync(ILease lease, string lastContinuationToken)
         {
             if (lease == null)
                 throw new ArgumentNullException(nameof(lease));
 
             string partitionId = lease.PartitionId;
-            string continuationToken = lease.ContinuationToken;
 
             Logger.InfoFormat("Partition {0} is gone due to split", partitionId);
             List<PartitionKeyRange> ranges = await this.EnumPartitionKeyRangesAsync().ConfigureAwait(false);
@@ -64,7 +63,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Bootstrapping
             await addedPartitionIds.ForEachAsync(
                 async addedRangeId =>
                 {
-                    ILease newLease = await this.leaseManager.CreateLeaseIfNotExistAsync(addedRangeId, continuationToken).ConfigureAwait(false);
+                    ILease newLease = await this.leaseManager.CreateLeaseIfNotExistAsync(addedRangeId, lastContinuationToken).ConfigureAwait(false);
                     newLeases.Enqueue(newLease);
                 },
                 this.degreeOfParallelism).ConfigureAwait(false);

--- a/src/DocumentDB.ChangeFeedProcessor/Bootstrapping/PartitionSynchronizer.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Bootstrapping/PartitionSynchronizer.cs
@@ -43,12 +43,13 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Bootstrapping
             await this.CreateLeasesAsync(partitionIds).ConfigureAwait(false);
         }
 
-        public async Task<IEnumerable<ILease>> SplitPartitionAsync(ILease lease, string lastContinuationToken)
+        public async Task<IEnumerable<ILease>> SplitPartitionAsync(ILease lease)
         {
             if (lease == null)
                 throw new ArgumentNullException(nameof(lease));
 
             string partitionId = lease.PartitionId;
+            string lastContinuationToken = lease.ContinuationToken;
 
             Logger.InfoFormat("Partition {0} is gone due to split", partitionId);
             List<PartitionKeyRange> ranges = await this.EnumPartitionKeyRangesAsync().ConfigureAwait(false);

--- a/src/DocumentDB.ChangeFeedProcessor/Exceptions/PartitionException.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Exceptions/PartitionException.cs
@@ -13,22 +13,6 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
     public class PartitionException : Exception
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="PartitionException" /> class.
-        /// </summary>
-        protected PartitionException()
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PartitionException"/> class using error message.
-        /// </summary>
-        /// <param name="message">The exception error message.</param>
-        protected PartitionException(string message)
-            : base(message)
-        {
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="PartitionException"/> class using error message and last continuation token.
         /// </summary>
         /// <param name="message">The exception error message.</param>
@@ -43,10 +27,12 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
         /// Initializes a new instance of the <see cref="PartitionException" /> class using error message and inner exception.
         /// </summary>
         /// <param name="message">The exception error message.</param>
+        /// <param name="lastContinuation"> Request continuation token </param>
         /// <param name="innerException">The inner exception.</param>
-        protected PartitionException(string message, Exception innerException)
+        protected PartitionException(string message, string lastContinuation, Exception innerException)
             : base(message, innerException)
         {
+            this.LastContinuation = lastContinuation;
         }
 
         /// <summary>

--- a/src/DocumentDB.ChangeFeedProcessor/Exceptions/PartitionNotFoundException.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Exceptions/PartitionNotFoundException.cs
@@ -13,22 +13,6 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
     public class PartitionNotFoundException : PartitionException
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="PartitionNotFoundException" /> class.
-        /// </summary>
-        public PartitionNotFoundException()
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PartitionNotFoundException"/> class using error message.
-        /// </summary>
-        /// <param name="message">The exception error message.</param>
-        public PartitionNotFoundException(string message)
-            : base(message)
-        {
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="PartitionNotFoundException"/> class using error message and last continuation token.
         /// </summary>
         /// <param name="message">The exception error message.</param>
@@ -42,9 +26,10 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
         /// Initializes a new instance of the <see cref="PartitionNotFoundException" /> class using error message and inner exception.
         /// </summary>
         /// <param name="message">The exception error message.</param>
+        /// <param name="lastContinuation">The last known continuation token</param>
         /// <param name="innerException">The inner exception.</param>
-        public PartitionNotFoundException(string message, Exception innerException)
-            : base(message, innerException)
+        public PartitionNotFoundException(string message, string lastContinuation, Exception innerException)
+            : base(message, lastContinuation, innerException)
         {
         }
 

--- a/src/DocumentDB.ChangeFeedProcessor/Exceptions/PartitionSplitException.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Exceptions/PartitionSplitException.cs
@@ -13,29 +13,12 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
     public class PartitionSplitException : PartitionException
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="PartitionSplitException" /> class.
-        /// </summary>
-        public PartitionSplitException()
-        {
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="PartitionSplitException"/> class using error message and last continuation token.
         /// </summary>
         /// <param name="message">The exception error message.</param>
         /// <param name="lastContinuation"> Request continuation token.</param>
         public PartitionSplitException(string message, string lastContinuation)
             : base(message, lastContinuation)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PartitionSplitException" /> class using error message and inner exception.
-        /// </summary>
-        /// <param name="message">The exception error message.</param>
-        /// <param name="innerException">The inner exception.</param>
-        public PartitionSplitException(string message, Exception innerException)
-            : base(message, innerException)
         {
         }
 

--- a/src/DocumentDB.ChangeFeedProcessor/Exceptions/PartitionSplitException.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Exceptions/PartitionSplitException.cs
@@ -20,15 +20,6 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PartitionSplitException"/> class using error message.
-        /// </summary>
-        /// <param name="message">The exception error message.</param>
-        public PartitionSplitException(string message)
-            : base(message)
-        {
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="PartitionSplitException"/> class using error message and last continuation token.
         /// </summary>
         /// <param name="message">The exception error message.</param>

--- a/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/IPartitionSynchronizer.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/IPartitionSynchronizer.cs
@@ -14,6 +14,6 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement
     {
         Task CreateMissingLeasesAsync();
 
-        Task<IEnumerable<ILease>> SplitPartitionAsync(ILease lease);
+        Task<IEnumerable<ILease>> SplitPartitionAsync(ILease lease, string lastContinuationToken);
     }
 }

--- a/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/IPartitionSynchronizer.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/IPartitionSynchronizer.cs
@@ -14,6 +14,6 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement
     {
         Task CreateMissingLeasesAsync();
 
-        Task<IEnumerable<ILease>> SplitPartitionAsync(ILease lease, string lastContinuationToken);
+        Task<IEnumerable<ILease>> SplitPartitionAsync(ILease lease);
     }
 }

--- a/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/PartitionController.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/PartitionController.cs
@@ -134,7 +134,8 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement
         {
             try
             {
-                IEnumerable<ILease> addedLeases = await this.synchronizer.SplitPartitionAsync(lease, lastContinuationToken).ConfigureAwait(false);
+                lease.ContinuationToken = lastContinuationToken;
+                IEnumerable<ILease> addedLeases = await this.synchronizer.SplitPartitionAsync(lease).ConfigureAwait(false);
                 Task[] addLeaseTasks = addedLeases.Select(l =>
                     {
                         l.Properties = lease.Properties;


### PR DESCRIPTION
PartitionController didn't pass actual continuation token to the  synchronizer -> when split occured, the continuation token from the "open partition time" was used which triggers processing same documents at least 2x