### PR TITLE
Fix NRE in case another host created child leases in case of partitio…

### DIFF
--- a/src/DocumentDB.ChangeFeedProcessor/Bootstrapping/PartitionSynchronizer.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Bootstrapping/PartitionSynchronizer.cs
@@ -65,7 +65,10 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Bootstrapping
                 async addedRangeId =>
                 {
                     ILease newLease = await this.leaseManager.CreateLeaseIfNotExistAsync(addedRangeId, lastContinuationToken).ConfigureAwait(false);
-                    newLeases.Enqueue(newLease);
+                    if (newLease != null)
+                    {
+                        newLeases.Enqueue(newLease);
+                    }
                 },
                 this.degreeOfParallelism).ConfigureAwait(false);
 


### PR DESCRIPTION
In case there is a partition split and the host fails to delete the parent lease, it can happen that other hosts will keep retrying to acquire the lease for an old partition and perform a split on it, which will always fail with a NRE, since `CreateLeaseIfNotExistAsync` returns `null` if a new lease already exists.

This causes a lot of contention, since the hosts will repeatedly try to acquire the old partition, which will always fail to split.

This PR changes `SplitPartitionAsync` so the already-existing partitions are filtered out of the result. This means that the host will not try to acquire the child partition which already exists (since we can safely assume that someone else is already processing it)