### PR TITLE
Legacy: Compatibility with v1: add back ChangeFeedEventHost.HostName property, which was in …

### DIFF
--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/Obsolete/ChangeFeedEventHostTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/Obsolete/ChangeFeedEventHostTests.cs
@@ -87,5 +87,13 @@
                     new DocumentCollectionInfo(),
                     new ChangeFeedHostOptions { DiscardExistingLeases = true }));
         }
+
+        [Fact]
+        public void ValidateHostName()
+        {
+            var hostName = "name";
+            var host = new ChangeFeedEventHost(hostName, new DocumentCollectionInfo(), new DocumentCollectionInfo());
+            Assert.Equal(hostName, host.HostName);
+        }
     }
 }

--- a/src/DocumentDB.ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
@@ -109,7 +109,6 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor
         private static readonly ILog Logger = LogProvider.GetCurrentClassLogger();
         private readonly TimeSpan sleepTime = TimeSpan.FromSeconds(15);
         private readonly TimeSpan lockTime = TimeSpan.FromSeconds(30);
-        private string hostName;
         private DocumentCollectionInfo feedCollectionLocation;
         private ChangeFeedProcessorOptions changeFeedProcessorOptions;
         private IChangeFeedDocumentClient feedDocumentClient;
@@ -122,6 +121,11 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor
         private IParitionLoadBalancingStrategy loadBalancingStrategy;
         private IPartitionProcessorFactory partitionProcessorFactory;
 
+        internal string HostName
+        {
+            get; private set;
+        }
+
         /// <summary>
         /// Sets the Host name.
         /// </summary>
@@ -129,7 +133,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor
         /// <returns>The instance of <see cref="ChangeFeedProcessorBuilder"/> to use.</returns>
         public ChangeFeedProcessorBuilder WithHostName(string hostName)
         {
-            this.hostName = hostName;
+            this.HostName = hostName;
             return this;
         }
 
@@ -307,7 +311,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor
         /// <returns>An instance of <see cref="IChangeFeedProcessor"/>.</returns>
         public async Task<IChangeFeedProcessor> BuildAsync()
         {
-            if (this.hostName == null)
+            if (this.HostName == null)
             {
                 throw new InvalidOperationException("Host name was not specified");
             }
@@ -395,7 +399,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor
             var partitionController = new PartitionController(leaseManager, partitionObserverFactory, synchronizer);
             if (this.loadBalancingStrategy == null)
             {
-                this.loadBalancingStrategy = new EqualPartitionsBalancingStrategy(this.hostName, this.changeFeedProcessorOptions.MinPartitionCount, this.changeFeedProcessorOptions.MaxPartitionCount, this.changeFeedProcessorOptions.LeaseExpirationInterval);
+                this.loadBalancingStrategy = new EqualPartitionsBalancingStrategy(this.HostName, this.changeFeedProcessorOptions.MinPartitionCount, this.changeFeedProcessorOptions.MaxPartitionCount, this.changeFeedProcessorOptions.LeaseExpirationInterval);
             }
 
             var partitionLoadBalancer = new PartitionLoadBalancer(partitionController, leaseManager, this.loadBalancingStrategy, this.changeFeedProcessorOptions.LeaseAcquireInterval);
@@ -410,7 +414,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor
                 var leaseManagerBuilder = new LeaseManagerBuilder()
                     .WithLeasePrefix(leasePrefix)
                     .WithLeaseCollection(this.leaseCollectionLocation)
-                    .WithHostName(this.hostName);
+                    .WithHostName(this.HostName);
 
                 if (this.leaseDocumentClient != null)
                 {

--- a/src/DocumentDB.ChangeFeedProcessor/DocumentDB.ChangeFeedProcessor.csproj
+++ b/src/DocumentDB.ChangeFeedProcessor/DocumentDB.ChangeFeedProcessor.csproj
@@ -21,7 +21,7 @@
     <AssemblyName>Microsoft.Azure.Documents.ChangeFeedProcessor</AssemblyName>
 
     <PackageId>Microsoft.Azure.DocumentDB.ChangeFeedProcessor</PackageId>
-    <PackageVersion>2.0.5</PackageVersion>
+    <PackageVersion>2.0.6</PackageVersion>
     <Title>Microsoft Azure Cosmos DB Change Feed Processor library</Title>
     <Authors>Microsoft</Authors>
     <PackageLicenseUrl>http://go.microsoft.com/fwlink/?LinkID=509837</PackageLicenseUrl>
@@ -44,9 +44,9 @@
     <!--CS1587:XML comment is not placed on a valid language element 
     LibLog files have misplaced comments, but we cannot touch them.-->
     <NoWarn>1587</NoWarn>
-    <Version>2.0.5</Version>
-    <AssemblyVersion>2.0.5.0</AssemblyVersion>
-    <FileVersion>2.0.5.0</FileVersion>
+    <Version>2.0.6</Version>
+    <AssemblyVersion>2.0.6.0</AssemblyVersion>
+    <FileVersion>2.0.6.0</FileVersion>
     <PackageReleaseNotes>The change log for this project is available at https://docs.microsoft.com/azure/cosmos-db/sql-api-sdk-dotnet-changefeed.
 </PackageReleaseNotes>
   </PropertyGroup>

--- a/src/DocumentDB.ChangeFeedProcessor/Obsolete/ChangeFeedEventHost.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Obsolete/ChangeFeedEventHost.cs
@@ -160,6 +160,13 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor
                 .WithLeaseCollection(leaseCollectionLocation);
         }
 
+        /// <summary>Gets the host name, which is a unique name for the instance.</summary>
+        /// <value>The host name.</value>
+        public string HostName
+        {
+            get { return this.builder.HostName; }
+        }
+
         /// <summary>Asynchronously registers the observer interface implementation with the host.
         /// This method also starts the host and enables it to start participating in the partition distribution process.</summary>
         /// <typeparam name="T">Implementation of your application-specific event observer.</typeparam>


### PR DESCRIPTION
…v1 but lost in translation to v2. A customer hit this when trying to upgrade to v2 (still using v1 API).