### PR TITLE
Updating references and bumping package number

### DIFF
--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/DocumentDB.ChangeFeedProcessor.UnitTests.csproj
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/DocumentDB.ChangeFeedProcessor.UnitTests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.9.1" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.0.0-preview" />
     <PackageReference Include="AutoFixture" Version="4.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.8.1" />

--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/DocumentDB.ChangeFeedProcessor.UnitTests.csproj
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/DocumentDB.ChangeFeedProcessor.UnitTests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.0.0-preview" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.0.0-preview2" />
     <PackageReference Include="AutoFixture" Version="4.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.8.1" />

--- a/src/DocumentDB.ChangeFeedProcessor/DocumentDB.ChangeFeedProcessor.csproj
+++ b/src/DocumentDB.ChangeFeedProcessor/DocumentDB.ChangeFeedProcessor.csproj
@@ -62,11 +62,11 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.0.0-preview" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.0.0-preview2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
-    <PackageReference Include="Microsoft.Azure.DocumentDB" Version="2.0.0-preview" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB" Version="2.0.0-preview2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DocumentDB.ChangeFeedProcessor/DocumentDB.ChangeFeedProcessor.csproj
+++ b/src/DocumentDB.ChangeFeedProcessor/DocumentDB.ChangeFeedProcessor.csproj
@@ -21,7 +21,7 @@
     <AssemblyName>Microsoft.Azure.Documents.ChangeFeedProcessor</AssemblyName>
 
     <PackageId>Microsoft.Azure.DocumentDB.ChangeFeedProcessor</PackageId>
-    <PackageVersion>2.0.6</PackageVersion>
+    <PackageVersion>2.1.0-preview</PackageVersion>
     <Title>Microsoft Azure Cosmos DB Change Feed Processor library</Title>
     <Authors>Microsoft</Authors>
     <PackageLicenseUrl>http://go.microsoft.com/fwlink/?LinkID=509837</PackageLicenseUrl>
@@ -44,9 +44,9 @@
     <!--CS1587:XML comment is not placed on a valid language element 
     LibLog files have misplaced comments, but we cannot touch them.-->
     <NoWarn>1587</NoWarn>
-    <Version>2.0.6</Version>
-    <AssemblyVersion>2.0.6.0</AssemblyVersion>
-    <FileVersion>2.0.6.0</FileVersion>
+    <Version>2.1.0-preview</Version>
+    <AssemblyVersion>2.1.0.0</AssemblyVersion>
+    <FileVersion>2.1.0.0</FileVersion>
     <PackageReleaseNotes>The change log for this project is available at https://docs.microsoft.com/azure/cosmos-db/sql-api-sdk-dotnet-changefeed.
 </PackageReleaseNotes>
   </PropertyGroup>
@@ -62,11 +62,11 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.9.1" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.0.0-preview" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
-    <PackageReference Include="Microsoft.Azure.DocumentDB" Version="1.21.1" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB" Version="2.0.0-preview" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR addresses an incompatibility that arises when using the CFP Library with Cosmos DB SDK 2.0.0 due to a change in some methods signature (introduction of CancellationToken in multiple methods).

Minor version bump also included, wasn't sure if we wanted it to be a pre-release or not.

Fixes #96 