### PR TITLE
Pr/log server timestamp

### DIFF
--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/PartitionManagement/DocumentServiceLeaseManagerTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/PartitionManagement/DocumentServiceLeaseManagerTests.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.PartitionManag
             public string PartitionId { get; set; }
             public string Owner { get; set; }
             public DateTime Timestamp { get; set; }
+            public DateTime ServerTimestamp { get; set; }
             public string ContinuationToken { get; set; }
             public string Id { get; set; }
             public string ConcurrencyToken { get; set; }

--- a/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/DocumentServiceLease.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/DocumentServiceLease.cs
@@ -50,9 +50,15 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement
         public string ContinuationToken { get; set; }
 
         [JsonIgnore]
+        public DateTime ServerTimestamp
+        {
+            get { return UnixStartTime.AddSeconds(this.TS); }
+        }
+
+        [JsonIgnore]
         public DateTime Timestamp
         {
-            get { return this.ExplicitTimestamp ?? UnixStartTime.AddSeconds(this.TS); }
+            get { return this.ExplicitTimestamp ?? this.ServerTimestamp; }
             set { this.ExplicitTimestamp = value; }
         }
 
@@ -80,11 +86,12 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement
         {
             return string.Format(
                 CultureInfo.InvariantCulture,
-                "{0} Owner='{1}' Continuation={2} Timestamp(local)={3}",
+                "{0} Owner='{1}' Continuation={2} Timestamp(local)={3} Timestamp(server)={4}",
                 this.Id,
                 this.Owner,
                 this.ContinuationToken,
-                this.Timestamp.ToLocalTime());
+                this.Timestamp.ToLocalTime(),
+                this.ServerTimestamp.ToUniversalTime());
         }
     }
 }

--- a/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/EqualPartitionsBalancingStrategy.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/EqualPartitionsBalancingStrategy.cs
@@ -118,10 +118,8 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement
             DateTime minUpdateTimeUtc = DateTime.UtcNow - this.leaseExpirationInterval;
             foreach (ILease lease in allLeases)
             {
-                Debug.Assert(lease.PartitionId != null, "TakeLeasesAsync: lease.PartitionId cannot be null.");
-
                 allPartitions.Add(lease.PartitionId, lease);
-                if (string.IsNullOrWhiteSpace(lease.Owner) || this.IsExpiredOrStuck(lease, minUpdateTimeUtc))
+                if (string.IsNullOrWhiteSpace(lease.Owner) || this.IsExpired(lease, minUpdateTimeUtc))
                 {
                     Logger.InfoFormat("Found unused or expired lease: {0}", lease);
                     expiredLeases.Add(lease);
@@ -147,9 +145,9 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement
             }
         }
 
-        private bool IsExpiredOrStuck(ILease lease, DateTime minUpdateTimeUtc)
+        private bool IsExpired(ILease lease, DateTime minUpdateTimeUtc)
         {
-            return lease.Timestamp.ToUniversalTime() < minUpdateTimeUtc || lease.ServerTimestamp.ToUniversalTime() < minUpdateTimeUtc;
+            return lease.Timestamp.ToUniversalTime() < minUpdateTimeUtc;
         }
     }
 }

--- a/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/EqualPartitionsBalancingStrategy.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/EqualPartitionsBalancingStrategy.cs
@@ -115,14 +115,15 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement
 
         private void CategorizeLeases(IEnumerable<ILease> allLeases, Dictionary<string, ILease> allPartitions, List<ILease> expiredLeases, Dictionary<string, int> workerToPartitionCount)
         {
+            DateTime minUpdateTimeUtc = DateTime.UtcNow - this.leaseExpirationInterval;
             foreach (ILease lease in allLeases)
             {
                 Debug.Assert(lease.PartitionId != null, "TakeLeasesAsync: lease.PartitionId cannot be null.");
 
                 allPartitions.Add(lease.PartitionId, lease);
-                if (string.IsNullOrWhiteSpace(lease.Owner) || this.IsExpired(lease))
+                if (string.IsNullOrWhiteSpace(lease.Owner) || this.IsExpiredOrStuck(lease, minUpdateTimeUtc))
                 {
-                    Logger.DebugFormat("Found unused or expired lease: {0}", lease);
+                    Logger.InfoFormat("Found unused or expired lease: {0}", lease);
                     expiredLeases.Add(lease);
                 }
                 else
@@ -146,9 +147,9 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement
             }
         }
 
-        private bool IsExpired(ILease lease)
+        private bool IsExpiredOrStuck(ILease lease, DateTime minUpdateTimeUtc)
         {
-            return lease.Timestamp.ToUniversalTime() + this.leaseExpirationInterval < DateTime.UtcNow;
+            return lease.Timestamp.ToUniversalTime() < minUpdateTimeUtc || lease.ServerTimestamp.ToUniversalTime() < minUpdateTimeUtc;
         }
     }
 }

--- a/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/ILease.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/ILease.cs
@@ -50,6 +50,11 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement
         string ConcurrencyToken { get; }
 
         /// <summary>
+        /// Gets the timestamp of the lease update on the server.
+        /// </summary>
+        DateTime ServerTimestamp { get; }
+
+        /// <summary>
         /// Gets or sets custom lease properties which can be managed from <see cref="IParitionLoadBalancingStrategy"/>.
         /// </summary>
         Dictionary<string, string> Properties { get; set; }


### PR DESCRIPTION
In order to do better diagnosing process, it's good to log "expired/stuck" partitions.

Q: could we also open it on ILease? So that in case I write my own balancer I will have also server time and in case of time skew I could detect it.

@mkolt : wdyt?