### PR TITLE
Support for new Session Token format 

### DIFF
--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/PartitionManagement/RemainingWorkEstimatorTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/PartitionManagement/RemainingWorkEstimatorTests.cs
@@ -264,7 +264,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.PartitionManag
                         await ctsAll.Task;
                         return r;
                     })
-                    .SetupQueryResponse("2", "200", "201", "2:201", async r =>
+                    .SetupQueryResponse("2", "200", "201", "2:-1#201", async r =>
                     {
                         cts2.SetResult(true);
                         await ctsAll.Task;

--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/PartitionManagement/RemainingWorkEstimatorTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/PartitionManagement/RemainingWorkEstimatorTests.cs
@@ -284,5 +284,28 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.PartitionManag
             Assert.Equal(2, pendingWork.Count);
         }
 
+        [Fact]
+        public void ExtractLsnFromSessionToken_ShouldParseOldSessionToken()
+        {
+            string oldToken = "0:12345";
+            string expectedLsn = "12345";
+            Assert.Equal(expectedLsn, RemainingWorkEstimator.ExtractLsnFromSessionToken(oldToken));
+        }
+
+        [Fact]
+        public void ExtractLsnFromSessionToken_ShouldParseNewSessionToken()
+        {
+            string newToken = "0:-1#12345";
+            string expectedLsn = "12345";
+            Assert.Equal(expectedLsn, RemainingWorkEstimator.ExtractLsnFromSessionToken(newToken));
+        }
+
+        [Fact]
+        public void ExtractLsnFromSessionToken_ShouldParseNewSessionTokenWithMultipleRegionalLsn()
+        {
+            string newTokenWithRegionalLsn = "0:-1#12345#Region1=1#Region2=2";
+            string expectedLsn = "12345";
+            Assert.Equal(expectedLsn, RemainingWorkEstimator.ExtractLsnFromSessionToken(newTokenWithRegionalLsn));
+        }
     }
 }

--- a/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/RemainingWorkEstimator.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/RemainingWorkEstimator.cs
@@ -115,7 +115,8 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement
                 return string.Empty;
             }
 
-            int separatorIndex = sessionToken.IndexOf(':');
+            int hashSeparator = sessionToken.IndexOf('#');
+            int separatorIndex = hashSeparator > -1 ? hashSeparator : sessionToken.IndexOf(':');
             return sessionToken.Substring(separatorIndex + 1);
         }
 

--- a/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/RemainingWorkEstimator.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/RemainingWorkEstimator.cs
@@ -112,24 +112,6 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement
             return segments[1];
         }
 
-        internal static string ExtractLsnFromDocument(string documentLsn)
-        {
-            if (string.IsNullOrEmpty(documentLsn))
-            {
-                return string.Empty;
-            }
-
-            string[] segments = documentLsn.Split(RemainingWorkEstimator.SegmentSeparator);
-
-            if (segments.Length < 2)
-            {
-                return segments[0];
-            }
-
-            // GlobalLsn
-            return segments[1];
-        }
-
         private static Document GetFirstDocument(IFeedResponse<Document> response)
         {
             using (IEnumerator<Document> e = response.GetEnumerator())
@@ -172,7 +154,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement
                 response = await query.ExecuteNextAsync<Document>().ConfigureAwait(false);
                 long parsedLSNFromSessionToken = TryConvertToNumber(ExtractLsnFromSessionToken(response.SessionToken));
                 long lastQueryLSN = response.Count > 0
-                    ? TryConvertToNumber(ExtractLsnFromDocument(GetFirstDocument(response).GetPropertyValue<string>(LSNPropertyName))) - 1
+                    ? TryConvertToNumber(GetFirstDocument(response).GetPropertyValue<string>(LSNPropertyName)) - 1
                     : parsedLSNFromSessionToken;
                 if (lastQueryLSN < 0)
                 {


### PR DESCRIPTION
When using SDK > 2.X, the Session Token format has changed. This made it so the Estimator did not produce results because it was not able to parse the new format (instead of being `{Partition}:{LSN}` it's `{Partition}:{-1}#{LSN}).

This PR adds support for both formats.