### PR TITLE
Support for PK lease collections: fix Lease Manager: pass request options with PK for delete

### DIFF
--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/PartitionManagement/DocumentServiceLeaseManagerTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/PartitionManagement/DocumentServiceLeaseManagerTests.cs
@@ -503,7 +503,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.PartitionManag
         }
 
         [Fact]
-        public async Task DeleteAsync_PassesParttionKeyIfPeaseCollectionIsPartitioned()
+        public async Task DeleteAsync_PassesPartitionKeyIfLeaseCollectionIsPartitioned()
         {
             var documentClient = Mock.Of<IChangeFeedDocumentClient>();
             var cachedLease = CreateCachedLease(owner);
@@ -597,7 +597,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.PartitionManag
                 documentClient,
                 leaseUpdater,
                 collectionInfo,
-                new RequestOptionsFactoryForFixedCollection(),
+                requestOptionsFactory ?? Mock.Of<IRequestOptionsFactory>(),
                 storeNamePrefix,
                 collectionLink,
                 hostName);

--- a/src/DocumentDB.ChangeFeedProcessor/DocumentDB.ChangeFeedProcessor.csproj
+++ b/src/DocumentDB.ChangeFeedProcessor/DocumentDB.ChangeFeedProcessor.csproj
@@ -21,7 +21,7 @@
     <AssemblyName>Microsoft.Azure.Documents.ChangeFeedProcessor</AssemblyName>
 
     <PackageId>Microsoft.Azure.DocumentDB.ChangeFeedProcessor</PackageId>
-    <PackageVersion>2.2.1</PackageVersion>
+    <PackageVersion>2.2.2</PackageVersion>
     <Title>Microsoft Azure Cosmos DB Change Feed Processor library</Title>
     <Authors>Microsoft</Authors>
     <PackageLicenseUrl>http://go.microsoft.com/fwlink/?LinkID=509837</PackageLicenseUrl>
@@ -44,9 +44,9 @@
     <!--CS1587:XML comment is not placed on a valid language element 
     LibLog files have misplaced comments, but we cannot touch them.-->
     <NoWarn>1587</NoWarn>
-    <Version>2.2.1</Version>
-    <AssemblyVersion>2.2.1.0</AssemblyVersion>
-    <FileVersion>2.2.1.0</FileVersion>
+    <Version>2.2.2</Version>
+    <AssemblyVersion>2.2.2.0</AssemblyVersion>
+    <FileVersion>2.2.2.0</FileVersion>
     <PackageReleaseNotes>The change log for this project is available at https://docs.microsoft.com/azure/cosmos-db/sql-api-sdk-dotnet-changefeed.
 </PackageReleaseNotes>
   </PropertyGroup>

--- a/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/DocumentServiceLeaseManager.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/DocumentServiceLeaseManager.cs
@@ -217,7 +217,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement
             Uri leaseUri = this.CreateDocumentUri(lease.Id);
             try
             {
-                await this.parameters.Client.DeleteDocumentAsync(
+                await this.client.DeleteDocumentAsync(
                     leaseUri,
                     this.requestOptionsFactory.CreateRequestOptions(lease)).ConfigureAwait(false);
             }

--- a/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/DocumentServiceLeaseManager.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/DocumentServiceLeaseManager.cs
@@ -217,7 +217,9 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement
             Uri leaseUri = this.CreateDocumentUri(lease.Id);
             try
             {
-                await this.client.DeleteDocumentAsync(leaseUri).ConfigureAwait(false);
+                await this.parameters.Client.DeleteDocumentAsync(
+                    leaseUri,
+                    this.requestOptionsFactory.CreateRequestOptions(lease)).ConfigureAwait(false);
             }
             catch (DocumentClientException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
             {

--- a/src/DocumentDB.ChangeFeedProcessor/Utils/DocumentCollectionHelper.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Utils/DocumentCollectionHelper.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Utils
 
     internal static class DocumentCollectionHelper
     {
-        private const string DefaultUserAgentSuffix = "changefeed-2.2.1";
+        private const string DefaultUserAgentSuffix = "changefeed-2.2.2";
 
         public static DocumentCollectionInfo Canonicalize(this DocumentCollectionInfo collectionInfo)
         {


### PR DESCRIPTION
This is only used in split scenario.
This has 2 changes:
    1) cherry-pick https://github.com/Azure/azure-documentdb-changefeedprocessor-dotnet/pull/115/commits/388a5879106d02a2438e2fb9c09dd7633c10460c and merge/resolve
    2) Bump the version 2.2.1 -> 2.2.2.