### PR TITLE
Trivial fix for last minute change in CFPBuilder.GetLeaseStoreManagerAsync

### DIFF
--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/ChangeFeedProcessorBuilderTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/ChangeFeedProcessorBuilderTests.cs
@@ -232,7 +232,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests
         }
 
         [Fact]
-        public async Task Build_PassesEnableCrossPartitionQuery_WhenLeaseCollectionIsPartitionedById()
+        public async Task BuildPassesEnableCrossPartitionQuery_WhenLeaseCollectionIsPartitionedById()
         {
             var leaseCollection = MockHelpers.CreateCollection(
                 "collectionId",
@@ -263,7 +263,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests
         }
 
         [Fact]
-        public async Task Build_PassesPartitionKey_WhenLeaseCollectionIsPartitionedById()
+        public async Task BuildPassesPartitionKey_WhenLeaseCollectionIsPartitionedById()
         {
             var leaseCollection = MockHelpers.CreateCollection(
                 "collectionId",

--- a/src/DocumentDB.ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
@@ -458,7 +458,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor
             if (this.LeaseStoreManager == null)
             {
                 var leaseDocumentClient = this.leaseDocumentClient ?? this.leaseCollectionLocation.CreateDocumentClient();
-                var collection = await this.leaseDocumentClient.GetDocumentCollectionAsync(collectionInfo).ConfigureAwait(false);
+                var collection = await leaseDocumentClient.GetDocumentCollectionAsync(collectionInfo).ConfigureAwait(false);
 
                 bool isPartitioned =
                     collection.PartitionKey != null &&


### PR DESCRIPTION
Missed to remove last "this." from this.leaseDocumentClient in CFPBuilder.GetLeaseStoreManagerAsync.