### PR TITLE
Feature parity with v1 for start continuation.

### DIFF
--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/Exceptions/PartitionExceptionsTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/Exceptions/PartitionExceptionsTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.Exceptions
                 FeedPollDelay = TimeSpan.FromMilliseconds(16),
                 MaxItemCount = 5,
                 PartitionKeyRangeId = "keyRangeId",
-                RequestContinuation = "initialToken"
+                StartContinuation = "initialToken"
             };
 
             var document = new Document();

--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/FeedProcessor/PartitionChainingTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/FeedProcessor/PartitionChainingTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.FeedProcessor
                 MaxItemCount = 5,
                 FeedPollDelay = TimeSpan.FromMilliseconds(16),
                 PartitionKeyRangeId = "keyRangeId",
-                RequestContinuation = "initialToken"
+                StartContinuation = "initialToken"
             };
 
             var document = new Document();

--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/FeedProcessor/PartitionProcessorTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/FeedProcessor/PartitionProcessorTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.FeedProcessor
                 FeedPollDelay = TimeSpan.FromMilliseconds(16),
                 MaxItemCount = 5,
                 PartitionKeyRangeId = "keyRangeId",
-                RequestContinuation = "initialToken"
+                StartContinuation = "initialToken"
             };
 
             var document = new Document();
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.FeedProcessor
                         It.Is<string>(s => s == processorSettings.CollectionSelfLink),
                         It.Is<ChangeFeedOptions>(options =>
                             options.PartitionKeyRangeId == processorSettings.PartitionKeyRangeId &&
-                            options.RequestContinuation == processorSettings.RequestContinuation)),
+                            options.RequestContinuation == processorSettings.StartContinuation)),
                     Times.Once);
         }
 

--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/Obsolete/ChangeFeedEventHostTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/Obsolete/ChangeFeedEventHostTests.cs
@@ -40,7 +40,7 @@
             Assert.Equal(1, processorOptions.MaxItemCount);
             Assert.True(processorOptions.StartFromBeginning);
             Assert.Equal(startTime, processorOptions.StartTime);
-            Assert.Equal("RequestContinuation", processorOptions.RequestContinuation);
+            Assert.Equal("RequestContinuation", processorOptions.StartContinuation);
             Assert.Equal("SessionToken", processorOptions.SessionToken);
             Assert.Equal(TimeSpan.FromSeconds(2), processorOptions.LeaseRenewInterval);
             Assert.Equal(TimeSpan.FromSeconds(3), processorOptions.LeaseAcquireInterval);

--- a/src/DocumentDB.ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
@@ -420,7 +420,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor
                 this.changeFeedProcessorOptions.DegreeOfParallelism,
                 this.changeFeedProcessorOptions.QueryPartitionsMaxBatchSize);
             var bootstrapper = new Bootstrapper(synchronizer, leaseStoreManager, this.lockTime, this.sleepTime);
-            var partitionObserverFactory = new PartitionSupervisorFactory(
+            var partitionSuperviserFactory = new PartitionSupervisorFactory(
                 factory,
                 leaseStoreManager,
                 this.partitionProcessorFactory ?? new PartitionProcessorFactory(this.feedDocumentClient, this.changeFeedProcessorOptions, leaseStoreManager, feedCollectionSelfLink),
@@ -435,7 +435,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor
                     this.changeFeedProcessorOptions.LeaseExpirationInterval);
             }
 
-            IPartitionController partitionController = new PartitionController(leaseStoreManager, leaseStoreManager, partitionObserverFactory, synchronizer);
+            IPartitionController partitionController = new PartitionController(leaseStoreManager, leaseStoreManager, partitionSuperviserFactory, synchronizer);
 
             if (this.healthMonitor == null)
             {

--- a/src/DocumentDB.ChangeFeedProcessor/ChangeFeedProcessorOptions.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/ChangeFeedProcessorOptions.cs
@@ -5,6 +5,7 @@
 namespace Microsoft.Azure.Documents.ChangeFeedProcessor
 {
     using System;
+    using Microsoft.Azure.Documents.Client;
 
     /// <summary>
     /// Options to control various aspects of partition distribution happening within <see cref="ChangeFeedProcessor"/> instance.
@@ -67,14 +68,25 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor
         public int? MaxItemCount { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether change feed in the Azure Cosmos DB service should start from beginning (true) or from current (false).
-        /// By default it's start from current (false).
+        /// Gets or sets the start request continuation token to start looking for changes after.
         /// </summary>
-        public bool StartFromBeginning { get; set; }
+        /// <remarks>
+        /// This is only used when lease store is not initialized and is ignored if a lease for partition exists and has continuation token.
+        /// If this is specified, both StartTime and StartFromBeginning are ignored.
+        /// </remarks>
+        /// <seealso cref="ChangeFeedOptions.RequestContinuation"/>
+        public string StartContinuation { get; set; }
 
         /// <summary>
-        /// Gets or sets the time (exclusive) to start looking for changes after. If this is specified, StartFromBeginning is ignored.
+        /// Gets or sets the time (exclusive) to start looking for changes after.
         /// </summary>
+        /// <remarks>
+        /// This is only used when:
+        /// (1) Lease store is not initialized and is ignored if a lease for partition exists and has continuation token.
+        /// (2) StartContinuation is not specified.
+        /// If this is specified, StartFromBeginning is ignored.
+        /// </remarks>
+        /// <seealso cref="ChangeFeedOptions.StartTime"/>
         public DateTime? StartTime
         {
             get
@@ -91,14 +103,22 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether change feed in the Azure Cosmos DB service should start from beginning (true) or from current (false).
+        /// By default it's start from current (false).
+        /// </summary>
+        /// <remarks>
+        /// This is only used when:
+        /// (1) Lease store is not initialized and is ignored if a lease for partition exists and has continuation token.
+        /// (2) StartContinuation is not specified.
+        /// (3) StartTime is not specified.
+        /// </remarks>
+        /// <seealso cref="ChangeFeedOptions.StartFromBeginning"/>
+        public bool StartFromBeginning { get; set; }
+
+        /// <summary>
         /// Gets or sets the session token for use with session consistency in the Azure Cosmos DB service.
         /// </summary>
         public string SessionToken { get; set; }
-
-        /// <summary>
-        /// Gets or sets the request continuation token in the Azure Cosmos DB service.
-        /// </summary>
-        internal string RequestContinuation { get; set; }
 
         /// <summary>
         /// Gets or sets the minimum partition count for the host.

--- a/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/PartitionProcessor.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/PartitionProcessor.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing
                 PartitionKeyRangeId = settings.PartitionKeyRangeId,
                 SessionToken = settings.SessionToken,
                 StartFromBeginning = settings.StartFromBeginning,
-                RequestContinuation = settings.RequestContinuation,
+                RequestContinuation = settings.StartContinuation,
                 StartTime = settings.StartTime,
             };
 
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing
 
         public async Task RunAsync(CancellationToken cancellationToken)
         {
-            string lastContinuation = this.settings.RequestContinuation;
+            string lastContinuation = this.settings.StartContinuation;
 
             while (!cancellationToken.IsCancellationRequested)
             {

--- a/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/PartitionProcessorFactory.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/PartitionProcessorFactory.cs
@@ -41,9 +41,9 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing
             var settings = new ProcessorSettings
             {
                 CollectionSelfLink = this.collectionSelfLink,
-                RequestContinuation = !string.IsNullOrEmpty(lease.ContinuationToken) ?
+                StartContinuation = !string.IsNullOrEmpty(lease.ContinuationToken) ?
                     lease.ContinuationToken :
-                    this.changeFeedProcessorOptions.RequestContinuation,
+                    this.changeFeedProcessorOptions.StartContinuation,
                 PartitionKeyRangeId = lease.PartitionId,
                 FeedPollDelay = this.changeFeedProcessorOptions.FeedPollDelay,
                 MaxItemCount = this.changeFeedProcessorOptions.MaxItemCount,

--- a/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/ProcessorSettings.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/ProcessorSettings.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing
 
         public int? MaxItemCount { get; set; }
 
-        public string RequestContinuation { get; set; }
-
         public TimeSpan FeedPollDelay { get; set; }
+
+        public string StartContinuation { get; set; }
 
         public bool StartFromBeginning { get; set; }
 

--- a/src/DocumentDB.ChangeFeedProcessor/Obsolete/ChangeFeedEventHost.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Obsolete/ChangeFeedEventHost.cs
@@ -241,7 +241,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor
                 MaxItemCount = feedOptions.MaxItemCount,
                 StartFromBeginning = feedOptions.StartFromBeginning,
                 StartTime = feedOptions.StartTime,
-                RequestContinuation = feedOptions.RequestContinuation,
+                StartContinuation = feedOptions.RequestContinuation,
                 SessionToken = feedOptions.SessionToken,
 
                 LeaseRenewInterval = hostOptions.LeaseRenewInterval,

--- a/src/DocumentDB.ChangeFeedProcessor/Utils/DocumentClientExtensions.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Utils/DocumentClientExtensions.cs
@@ -43,10 +43,10 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Utils
                 return response.Resource;
             }
             catch (DocumentClientException ex) when (ex.StatusCode == HttpStatusCode.Conflict)
-                {
+            {
                 return null;    // Ignore -- document already exists.
-                }
             }
+        }
 
         public static async Task<Document> TryDeleteDocumentAsync(
             this IChangeFeedDocumentClient client,


### PR DESCRIPTION
Making internal ChangeFeedProcessorOptions.RequestContinuation -> public ChangeFeedProcessorOptions.StartContinuation for feature parity with v1, as requested by users and PM. Note that the name is *Start*Continuation to make it explicit that this is only for starting the feed, similar to StartTime and StartFromBeginning.

Fixing xmldoc comments to explaining in more details about Start options.

Also renaming internal ProcessorSettings from RequestContinuation to StartContinuation to be more consistent with the public setting.

Unit test.