### PR TITLE
Splits on Shared Throughput scenario

### DIFF
--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/PartitionManagement/PartitionSynchronizerTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/PartitionManagement/PartitionSynchronizerTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.Documents.ChangeFeedProcessor.Bootstrapping;
 using Microsoft.Azure.Documents.ChangeFeedProcessor.DataAccess;
@@ -89,7 +90,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.PartitionManag
         }
 
         [Fact]
-        public async Task SplitPartitionAsync_ShouldThrow_IfSinglePartitionAndChildPartitionsLessThan2()
+        public async Task SplitPartitionAsync_ShouldThrow_IfCollectionProvisionedAndPKRangesReturn1()
         {
             const string lastKnowToken = "last know token";
             const string collectionLink = "collectionLink";
@@ -117,8 +118,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.PartitionManag
             var offerResponse = Mock.Of<IFeedResponse<Offer>>(r => r.GetEnumerator() == offers.GetEnumerator());
             IChangeFeedDocumentClient documentClient = Mock.Of<IChangeFeedDocumentClient>(c =>
                 c.ReadPartitionKeyRangeFeedAsync(It.IsAny<string>(), It.IsAny<FeedOptions>()) == Task.FromResult(keyRangeResponse)
-                && c.ReadOffersFeedAsync(It.IsAny<FeedOptions>()) == Task.FromResult(offerResponse)
-                );
+                && c.ReadOffersFeedAsync(It.IsAny<FeedOptions>()) == Task.FromResult(offerResponse));
 
             var lease20 = Mock.Of<ILease>();
             ILeaseManager leaseManager = Mock.Of<ILeaseManager>(m =>
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.PartitionManag
         }
 
         [Fact]
-        public async Task SplitPartitionAsync_ShouldPass_IfPartitionedAndChildPartitionsLessThan2()
+        public async Task SplitPartitionAsync_ShouldPass_IfDatabaseProvisionedAndPKRangesReturn1()
         {
             const string lastKnowToken = "last know token";
             const string databaseLink = "databaseLink";
@@ -149,6 +149,43 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.PartitionManag
             {
                 new Offer
                 {
+                    Id = "1",
+                    ResourceId = databaseLink
+                }
+            };
+
+            var lease = Mock.Of<ILease>(l => l.PartitionId == "10" && l.ContinuationToken == lastKnowToken);
+
+            var keyRangeResponse = Mock.Of<IFeedResponse<PartitionKeyRange>>(r => r.GetEnumerator() == keyRanges.GetEnumerator());
+            var offerResponse = Mock.Of<IFeedResponse<Offer>>(r => r.GetEnumerator() == offers.GetEnumerator());
+            IChangeFeedDocumentClient documentClient = Mock.Of<IChangeFeedDocumentClient>(c =>
+                c.ReadPartitionKeyRangeFeedAsync(It.IsAny<string>(), It.IsAny<FeedOptions>()) == Task.FromResult(keyRangeResponse)
+                && c.ReadOffersFeedAsync(It.IsAny<FeedOptions>()) == Task.FromResult(offerResponse));
+
+            var lease20 = Mock.Of<ILease>();
+            ILeaseManager leaseManager = Mock.Of<ILeaseManager>(m =>
+                m.CreateLeaseIfNotExistAsync("20", lastKnowToken) == Task.FromResult(lease20));
+            var leaseContainer = Mock.Of<ILeaseContainer>();
+
+            var sut = new PartitionSynchronizer(documentClient, collectionLink, leaseContainer, leaseManager, 1, int.MaxValue);
+            IEnumerable<ILease> result = await sut.SplitPartitionAsync(lease);
+            Assert.NotNull(result);
+            Assert.Equal(new[] { lease20 }, result);
+        }
+
+        [Fact]
+        public async Task SplitPartitionAsync_ShouldThrow_IfDatabaseProvisionedAndPKRangesReturn0()
+        {
+            const string lastKnowToken = "last know token";
+            const string databaseLink = "databaseLink";
+            const string collectionLink = "collectionLink";
+
+            IEnumerable<PartitionKeyRange> keyRanges = Enumerable.Empty<PartitionKeyRange>();
+
+            IEnumerable<Offer>offers = new[]
+            {
+                new Offer
+                {
                     Id = "1", 
                     ResourceId = databaseLink
                 }
@@ -160,8 +197,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.PartitionManag
             var offerResponse = Mock.Of<IFeedResponse<Offer>>(r => r.GetEnumerator() == offers.GetEnumerator());
             IChangeFeedDocumentClient documentClient = Mock.Of<IChangeFeedDocumentClient>(c =>
                 c.ReadPartitionKeyRangeFeedAsync(It.IsAny<string>(), It.IsAny<FeedOptions>()) == Task.FromResult(keyRangeResponse)
-                && c.ReadOffersFeedAsync(It.IsAny<FeedOptions>()) == Task.FromResult(offerResponse)
-                );
+                && c.ReadOffersFeedAsync(It.IsAny<FeedOptions>()) == Task.FromResult(offerResponse));
 
             var lease20 = Mock.Of<ILease>();
             ILeaseManager leaseManager = Mock.Of<ILeaseManager>(m =>
@@ -169,9 +205,8 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.PartitionManag
             var leaseContainer = Mock.Of<ILeaseContainer>();
 
             var sut = new PartitionSynchronizer(documentClient, collectionLink, leaseContainer, leaseManager, 1, int.MaxValue);
-            IEnumerable<ILease> result = await sut.SplitPartitionAsync(lease);
-            Assert.NotNull(result);
-            Assert.Equal(new[] { lease20 }, result);
+            Exception exception = await Record.ExceptionAsync(async () => await sut.SplitPartitionAsync(lease));
+            Assert.IsAssignableFrom<InvalidOperationException>(exception);
         }
     }
 }

--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/PartitionManagement/PartitionSynchronizerTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/PartitionManagement/PartitionSynchronizerTests.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Microsoft Corporation.  Licensed under the MIT license.
 //----------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
@@ -82,6 +83,92 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.PartitionManag
             var leaseContainer = Mock.Of<ILeaseContainer>();
 
             var sut = new PartitionSynchronizer(documentClient, "collectionlink", leaseContainer, leaseManager, 1, int.MaxValue);
+            IEnumerable<ILease> result = await sut.SplitPartitionAsync(lease);
+            Assert.NotNull(result);
+            Assert.Equal(new[] { lease20 }, result);
+        }
+
+        [Fact]
+        public async Task SplitPartitionAsync_ShouldThrow_IfSinglePartitionAndChildPartitionsLessThan2()
+        {
+            const string lastKnowToken = "last know token";
+            const string collectionLink = "collectionLink";
+
+            IEnumerable<PartitionKeyRange> keyRanges = new[]
+            {
+                new PartitionKeyRange
+                {
+                    Id = "20", Parents = new Collection<string>(new[] {"10"})
+                }
+            };
+
+            IEnumerable<Offer> offers = new[]
+            {
+                new Offer
+                {
+                    Id = "1",
+                    ResourceId = collectionLink
+                }
+            };
+
+            var lease = Mock.Of<ILease>(l => l.PartitionId == "10" && l.ContinuationToken == lastKnowToken);
+
+            var keyRangeResponse = Mock.Of<IFeedResponse<PartitionKeyRange>>(r => r.GetEnumerator() == keyRanges.GetEnumerator());
+            var offerResponse = Mock.Of<IFeedResponse<Offer>>(r => r.GetEnumerator() == offers.GetEnumerator());
+            IChangeFeedDocumentClient documentClient = Mock.Of<IChangeFeedDocumentClient>(c =>
+                c.ReadPartitionKeyRangeFeedAsync(It.IsAny<string>(), It.IsAny<FeedOptions>()) == Task.FromResult(keyRangeResponse)
+                && c.ReadOffersFeedAsync(It.IsAny<FeedOptions>()) == Task.FromResult(offerResponse)
+                );
+
+            var lease20 = Mock.Of<ILease>();
+            ILeaseManager leaseManager = Mock.Of<ILeaseManager>(m =>
+                m.CreateLeaseIfNotExistAsync("20", lastKnowToken) == Task.FromResult(lease20));
+            var leaseContainer = Mock.Of<ILeaseContainer>();
+
+            var sut = new PartitionSynchronizer(documentClient, collectionLink, leaseContainer, leaseManager, 1, int.MaxValue);
+            Exception exception = await Record.ExceptionAsync(async () => await sut.SplitPartitionAsync(lease));
+            Assert.IsAssignableFrom<InvalidOperationException>(exception);
+        }
+
+        [Fact]
+        public async Task SplitPartitionAsync_ShouldPass_IfPartitionedAndChildPartitionsLessThan2()
+        {
+            const string lastKnowToken = "last know token";
+            const string databaseLink = "databaseLink";
+            const string collectionLink = "collectionLink";
+
+            IEnumerable<PartitionKeyRange> keyRanges = new[]
+            {
+                new PartitionKeyRange
+                {
+                    Id = "20", Parents = new Collection<string>(new[] {"10"})
+                }
+            };
+
+            IEnumerable<Offer> offers = new[]
+            {
+                new Offer
+                {
+                    Id = "1", 
+                    ResourceId = databaseLink
+                }
+            };
+
+            var lease = Mock.Of<ILease>(l => l.PartitionId == "10" && l.ContinuationToken == lastKnowToken);
+
+            var keyRangeResponse = Mock.Of<IFeedResponse<PartitionKeyRange>>(r => r.GetEnumerator() == keyRanges.GetEnumerator());
+            var offerResponse = Mock.Of<IFeedResponse<Offer>>(r => r.GetEnumerator() == offers.GetEnumerator());
+            IChangeFeedDocumentClient documentClient = Mock.Of<IChangeFeedDocumentClient>(c =>
+                c.ReadPartitionKeyRangeFeedAsync(It.IsAny<string>(), It.IsAny<FeedOptions>()) == Task.FromResult(keyRangeResponse)
+                && c.ReadOffersFeedAsync(It.IsAny<FeedOptions>()) == Task.FromResult(offerResponse)
+                );
+
+            var lease20 = Mock.Of<ILease>();
+            ILeaseManager leaseManager = Mock.Of<ILeaseManager>(m =>
+                m.CreateLeaseIfNotExistAsync("20", lastKnowToken) == Task.FromResult(lease20));
+            var leaseContainer = Mock.Of<ILeaseContainer>();
+
+            var sut = new PartitionSynchronizer(documentClient, collectionLink, leaseContainer, leaseManager, 1, int.MaxValue);
             IEnumerable<ILease> result = await sut.SplitPartitionAsync(lease);
             Assert.NotNull(result);
             Assert.Equal(new[] { lease20 }, result);

--- a/src/DocumentDB.ChangeFeedProcessor/DataAccess/ChangeFeedDocumentClient.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/DataAccess/ChangeFeedDocumentClient.cs
@@ -156,5 +156,15 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.DataAccess
         {
             return this.documentClient.CreateDocumentQuery<T>(documentCollectionUri, querySpec, feedOptions);
         }
+
+        /// <summary>
+        /// Reads the list of Offers.
+        /// </summary>
+        /// <param name="options">The <see cref="Microsoft.Azure.Documents.Client.FeedOptions"/>for this request.</param>
+        /// <returns>A list of <see cref="Offer"/>.</returns>
+        public async Task<IFeedResponse<Offer>> ReadOffersFeedAsync(FeedOptions options = null)
+        {
+            return await this.documentClient.ReadOffersFeedAsync(options).ConfigureAwait(false);
+        }
     }
 }

--- a/src/DocumentDB.ChangeFeedProcessor/DataAccess/ChangeFeedDocumentClient.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/DataAccess/ChangeFeedDocumentClient.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.DataAccess
         }
 
         /// <summary>
-        /// Reads the list of Offers.
+        /// Reads the feed (sequence) of <see cref="Offer"/> for the database account.
         /// </summary>
         /// <param name="options">The <see cref="Microsoft.Azure.Documents.Client.FeedOptions"/>for this request.</param>
         /// <returns>A list of <see cref="Offer"/>.</returns>

--- a/src/DocumentDB.ChangeFeedProcessor/DataAccess/IChangeFeedDocumentClient.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/DataAccess/IChangeFeedDocumentClient.cs
@@ -120,5 +120,12 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.DataAccess
         /// <param name="feedOptions">Options for the query.</param>
         /// <returns>The query result set.</returns>
         IQueryable<T> CreateDocumentQuery<T>(string documentCollectionUri, SqlQuerySpec querySpec, FeedOptions feedOptions = null);
+
+        /// <summary>
+        /// Reads the list of Offers.
+        /// </summary>
+        /// <param name="options">The <see cref="Microsoft.Azure.Documents.Client.FeedOptions"/>for this request.</param>
+        /// <returns>A list of <see cref="Offer"/>.</returns>
+        Task<IFeedResponse<Offer>> ReadOffersFeedAsync(FeedOptions options = null);
     }
 }

--- a/src/DocumentDB.ChangeFeedProcessor/DataAccess/IChangeFeedDocumentClient.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/DataAccess/IChangeFeedDocumentClient.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.DataAccess
         IQueryable<T> CreateDocumentQuery<T>(string documentCollectionUri, SqlQuerySpec querySpec, FeedOptions feedOptions = null);
 
         /// <summary>
-        /// Reads the list of Offers.
+        /// Reads the feed (sequence) of <see cref="Offer"/> for the database account.
         /// </summary>
         /// <param name="options">The <see cref="Microsoft.Azure.Documents.Client.FeedOptions"/>for this request.</param>
         /// <returns>A list of <see cref="Offer"/>.</returns>

--- a/src/DocumentDB.ChangeFeedProcessor/DocumentDB.ChangeFeedProcessor.csproj
+++ b/src/DocumentDB.ChangeFeedProcessor/DocumentDB.ChangeFeedProcessor.csproj
@@ -21,7 +21,7 @@
     <AssemblyName>Microsoft.Azure.Documents.ChangeFeedProcessor</AssemblyName>
 
     <PackageId>Microsoft.Azure.DocumentDB.ChangeFeedProcessor</PackageId>
-    <PackageVersion>2.2.4</PackageVersion>
+    <PackageVersion>2.2.5</PackageVersion>
     <Title>Microsoft Azure Cosmos DB Change Feed Processor library</Title>
     <Authors>Microsoft</Authors>
     <PackageLicenseUrl>http://go.microsoft.com/fwlink/?LinkID=509837</PackageLicenseUrl>
@@ -44,9 +44,9 @@
     <!--CS1587:XML comment is not placed on a valid language element 
     LibLog files have misplaced comments, but we cannot touch them.-->
     <NoWarn>1587</NoWarn>
-    <Version>2.2.4</Version>
-    <AssemblyVersion>2.2.4.0</AssemblyVersion>
-    <FileVersion>2.2.4.0</FileVersion>
+    <Version>2.2.5</Version>
+    <AssemblyVersion>2.2.5.0</AssemblyVersion>
+    <FileVersion>2.2.5.0</FileVersion>
     <PackageReleaseNotes>The change log for this project is available at https://docs.microsoft.com/azure/cosmos-db/sql-api-sdk-dotnet-changefeed.
 </PackageReleaseNotes>
   </PropertyGroup>

--- a/src/DocumentDB.ChangeFeedProcessor/Utils/DocumentCollectionHelper.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Utils/DocumentCollectionHelper.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Utils
 
     internal static class DocumentCollectionHelper
     {
-        private const string DefaultUserAgentSuffix = "changefeed-2.2.4";
+        private const string DefaultUserAgentSuffix = "changefeed-2.2.5";
 
         public static DocumentCollectionInfo Canonicalize(this DocumentCollectionInfo collectionInfo)
         {


### PR DESCRIPTION
Add support for split for collections using shared database throughput.

Splits happening in a Shared Throughput scenario can yield 1 child PKRange in some scenarios. Currently we always expect that PKRange splits into 2 child ranges.

This PR adapts the `PartitionSynchronizer` behavior depending on the provision scenario of the container/collection.