### PR TITLE
Split fix for shared throughput collections

### DIFF
--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/PartitionManagement/PartitionSynchronizerTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/PartitionManagement/PartitionSynchronizerTests.cs
@@ -13,6 +13,7 @@ using Microsoft.Azure.Documents.ChangeFeedProcessor.LeaseManagement;
 using Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement;
 using Microsoft.Azure.Documents.Client;
 using Moq;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.PartitionManagement
@@ -103,13 +104,9 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.PartitionManag
                 }
             };
 
-            IEnumerable<Offer> offers = new[]
+            IEnumerable <Offer> offers = new[]
             {
-                new Offer
-                {
-                    Id = "1",
-                    ResourceId = collectionLink
-                }
+                JsonConvert.DeserializeObject<Offer>("{ \"id\":\"1\", \"resource\":\""+ collectionLink + "\"}")
             };
 
             var lease = Mock.Of<ILease>(l => l.PartitionId == "10" && l.ContinuationToken == lastKnowToken);
@@ -147,11 +144,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.PartitionManag
 
             IEnumerable<Offer> offers = new[]
             {
-                new Offer
-                {
-                    Id = "1",
-                    ResourceId = databaseLink
-                }
+                JsonConvert.DeserializeObject<Offer>("{ \"id\":\"1\", \"resource\":\""+ databaseLink + "\"}")
             };
 
             var lease = Mock.Of<ILease>(l => l.PartitionId == "10" && l.ContinuationToken == lastKnowToken);
@@ -182,13 +175,9 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.PartitionManag
 
             IEnumerable<PartitionKeyRange> keyRanges = Enumerable.Empty<PartitionKeyRange>();
 
-            IEnumerable<Offer>offers = new[]
+            IEnumerable<Offer> offers = new[]
             {
-                new Offer
-                {
-                    Id = "1", 
-                    ResourceId = databaseLink
-                }
+                JsonConvert.DeserializeObject<Offer>("{ \"id\":\"1\", \"resource\":\""+ databaseLink + "\"}")
             };
 
             var lease = Mock.Of<ILease>(l => l.PartitionId == "10" && l.ContinuationToken == lastKnowToken);

--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/PartitionManagement/PartitionSynchronizerTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/PartitionManagement/PartitionSynchronizerTests.cs
@@ -91,102 +91,18 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.PartitionManag
         }
 
         [Fact]
-        public async Task SplitPartitionAsync_ShouldThrow_IfCollectionProvisionedAndPKRangesReturn1()
+        public async Task SplitPartitionAsync_ShouldThrow_IfPKRangesReturn0()
         {
             const string lastKnowToken = "last know token";
-            const string collectionLink = "collectionLink";
-
-            IEnumerable<PartitionKeyRange> keyRanges = new[]
-            {
-                new PartitionKeyRange
-                {
-                    Id = "20", Parents = new Collection<string>(new[] {"10"})
-                }
-            };
-
-            IEnumerable <Offer> offers = new[]
-            {
-                JsonConvert.DeserializeObject<Offer>("{ \"id\":\"1\", \"resource\":\""+ collectionLink + "\"}")
-            };
-
-            var lease = Mock.Of<ILease>(l => l.PartitionId == "10" && l.ContinuationToken == lastKnowToken);
-
-            var keyRangeResponse = Mock.Of<IFeedResponse<PartitionKeyRange>>(r => r.GetEnumerator() == keyRanges.GetEnumerator());
-            var offerResponse = Mock.Of<IFeedResponse<Offer>>(r => r.GetEnumerator() == offers.GetEnumerator());
-            IChangeFeedDocumentClient documentClient = Mock.Of<IChangeFeedDocumentClient>(c =>
-                c.ReadPartitionKeyRangeFeedAsync(It.IsAny<string>(), It.IsAny<FeedOptions>()) == Task.FromResult(keyRangeResponse)
-                && c.ReadOffersFeedAsync(It.IsAny<FeedOptions>()) == Task.FromResult(offerResponse));
-
-            var lease20 = Mock.Of<ILease>();
-            ILeaseManager leaseManager = Mock.Of<ILeaseManager>(m =>
-                m.CreateLeaseIfNotExistAsync("20", lastKnowToken) == Task.FromResult(lease20));
-            var leaseContainer = Mock.Of<ILeaseContainer>();
-
-            var sut = new PartitionSynchronizer(documentClient, collectionLink, leaseContainer, leaseManager, 1, int.MaxValue);
-            Exception exception = await Record.ExceptionAsync(async () => await sut.SplitPartitionAsync(lease));
-            Assert.IsAssignableFrom<InvalidOperationException>(exception);
-        }
-
-        [Fact]
-        public async Task SplitPartitionAsync_ShouldPass_IfDatabaseProvisionedAndPKRangesReturn1()
-        {
-            const string lastKnowToken = "last know token";
-            const string databaseLink = "databaseLink";
-            const string collectionLink = "collectionLink";
-
-            IEnumerable<PartitionKeyRange> keyRanges = new[]
-            {
-                new PartitionKeyRange
-                {
-                    Id = "20", Parents = new Collection<string>(new[] {"10"})
-                }
-            };
-
-            IEnumerable<Offer> offers = new[]
-            {
-                JsonConvert.DeserializeObject<Offer>("{ \"id\":\"1\", \"resource\":\""+ databaseLink + "\"}")
-            };
-
-            var lease = Mock.Of<ILease>(l => l.PartitionId == "10" && l.ContinuationToken == lastKnowToken);
-
-            var keyRangeResponse = Mock.Of<IFeedResponse<PartitionKeyRange>>(r => r.GetEnumerator() == keyRanges.GetEnumerator());
-            var offerResponse = Mock.Of<IFeedResponse<Offer>>(r => r.GetEnumerator() == offers.GetEnumerator());
-            IChangeFeedDocumentClient documentClient = Mock.Of<IChangeFeedDocumentClient>(c =>
-                c.ReadPartitionKeyRangeFeedAsync(It.IsAny<string>(), It.IsAny<FeedOptions>()) == Task.FromResult(keyRangeResponse)
-                && c.ReadOffersFeedAsync(It.IsAny<FeedOptions>()) == Task.FromResult(offerResponse));
-
-            var lease20 = Mock.Of<ILease>();
-            ILeaseManager leaseManager = Mock.Of<ILeaseManager>(m =>
-                m.CreateLeaseIfNotExistAsync("20", lastKnowToken) == Task.FromResult(lease20));
-            var leaseContainer = Mock.Of<ILeaseContainer>();
-
-            var sut = new PartitionSynchronizer(documentClient, collectionLink, leaseContainer, leaseManager, 1, int.MaxValue);
-            IEnumerable<ILease> result = await sut.SplitPartitionAsync(lease);
-            Assert.NotNull(result);
-            Assert.Equal(new[] { lease20 }, result);
-        }
-
-        [Fact]
-        public async Task SplitPartitionAsync_ShouldThrow_IfDatabaseProvisionedAndPKRangesReturn0()
-        {
-            const string lastKnowToken = "last know token";
-            const string databaseLink = "databaseLink";
             const string collectionLink = "collectionLink";
 
             IEnumerable<PartitionKeyRange> keyRanges = Enumerable.Empty<PartitionKeyRange>();
 
-            IEnumerable<Offer> offers = new[]
-            {
-                JsonConvert.DeserializeObject<Offer>("{ \"id\":\"1\", \"resource\":\""+ databaseLink + "\"}")
-            };
-
             var lease = Mock.Of<ILease>(l => l.PartitionId == "10" && l.ContinuationToken == lastKnowToken);
 
             var keyRangeResponse = Mock.Of<IFeedResponse<PartitionKeyRange>>(r => r.GetEnumerator() == keyRanges.GetEnumerator());
-            var offerResponse = Mock.Of<IFeedResponse<Offer>>(r => r.GetEnumerator() == offers.GetEnumerator());
             IChangeFeedDocumentClient documentClient = Mock.Of<IChangeFeedDocumentClient>(c =>
-                c.ReadPartitionKeyRangeFeedAsync(It.IsAny<string>(), It.IsAny<FeedOptions>()) == Task.FromResult(keyRangeResponse)
-                && c.ReadOffersFeedAsync(It.IsAny<FeedOptions>()) == Task.FromResult(offerResponse));
+                c.ReadPartitionKeyRangeFeedAsync(It.IsAny<string>(), It.IsAny<FeedOptions>()) == Task.FromResult(keyRangeResponse));
 
             var lease20 = Mock.Of<ILease>();
             ILeaseManager leaseManager = Mock.Of<ILeaseManager>(m =>

--- a/src/DocumentDB.ChangeFeedProcessor/Bootstrapping/PartitionSynchronizer.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Bootstrapping/PartitionSynchronizer.cs
@@ -64,6 +64,8 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Bootstrapping
             string lastContinuationToken = lease.ContinuationToken;
 
             Logger.InfoFormat("Partition {0} is gone due to split", partitionId);
+
+            // After split the childs are all available
             List<PartitionKeyRange> ranges = await this.EnumPartitionKeyRangesAsync().ConfigureAwait(false);
             List<string> addedPartitionIds = ranges.Where(range => range.Parents.Contains(partitionId)).Select(range => range.Id).ToList();
             if (addedPartitionIds.Count == 0
@@ -142,7 +144,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Bootstrapping
             }
             while (!string.IsNullOrEmpty(response.ResponseContinuation));
 
-            this.hasCollectionProvisionedThroughput = offers.Any(x => x.ResourceId == this.collectionSelfLink);
+            this.hasCollectionProvisionedThroughput = offers.Any(x => x.ResourceLink == this.collectionSelfLink);
             return this.hasCollectionProvisionedThroughput.Value;
         }
 

--- a/src/DocumentDB.ChangeFeedProcessor/Bootstrapping/PartitionSynchronizer.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Bootstrapping/PartitionSynchronizer.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Bootstrapping
             List<string> addedPartitionIds = ranges.Where(range => range.Parents.Contains(partitionId)).Select(range => range.Id).ToList();
             if (addedPartitionIds.Count == 0)
             {
-                Logger.ErrorFormat("Partition {0} had split but we failed to find at least 2 child partitions", partitionId);
+                Logger.ErrorFormat("Partition {0} had split but we failed to find at least one child partition", partitionId);
                 throw new InvalidOperationException();
             }
 

--- a/src/DocumentDB.ChangeFeedProcessor/DataAccess/ChangeFeedDocumentClient.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/DataAccess/ChangeFeedDocumentClient.cs
@@ -156,15 +156,5 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.DataAccess
         {
             return this.documentClient.CreateDocumentQuery<T>(documentCollectionUri, querySpec, feedOptions);
         }
-
-        /// <summary>
-        /// Reads the feed (sequence) of <see cref="Offer"/> for the database account.
-        /// </summary>
-        /// <param name="options">The <see cref="Microsoft.Azure.Documents.Client.FeedOptions"/>for this request.</param>
-        /// <returns>A list of <see cref="Offer"/>.</returns>
-        public async Task<IFeedResponse<Offer>> ReadOffersFeedAsync(FeedOptions options = null)
-        {
-            return await this.documentClient.ReadOffersFeedAsync(options).ConfigureAwait(false);
-        }
     }
 }

--- a/src/DocumentDB.ChangeFeedProcessor/DataAccess/IChangeFeedDocumentClient.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/DataAccess/IChangeFeedDocumentClient.cs
@@ -120,12 +120,5 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.DataAccess
         /// <param name="feedOptions">Options for the query.</param>
         /// <returns>The query result set.</returns>
         IQueryable<T> CreateDocumentQuery<T>(string documentCollectionUri, SqlQuerySpec querySpec, FeedOptions feedOptions = null);
-
-        /// <summary>
-        /// Reads the feed (sequence) of <see cref="Offer"/> for the database account.
-        /// </summary>
-        /// <param name="options">The <see cref="Microsoft.Azure.Documents.Client.FeedOptions"/>for this request.</param>
-        /// <returns>A list of <see cref="Offer"/>.</returns>
-        Task<IFeedResponse<Offer>> ReadOffersFeedAsync(FeedOptions options = null);
     }
 }


### PR DESCRIPTION
This PR simplifies the check based on the fact that after split, either all or none of the child Partitions are available.