### PR TITLE
Change ChangeFeedProcessorBuilder to use IDocumentClient

### DIFF
--- a/src/DocumentDB.ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
@@ -165,11 +165,11 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor
         }
 
         /// <summary>
-        /// Sets an existing <see cref="DocumentClient"/> to be used to read from the monitored collection.
+        /// Sets an existing <see cref="IDocumentClient"/> to be used to read from the monitored collection.
         /// </summary>
-        /// <param name="feedDocumentClient">The instance of <see cref="DocumentClient"/> to use.</param>
+        /// <param name="feedDocumentClient">The instance of <see cref="IDocumentClient"/> to use.</param>
         /// <returns>The instance of <see cref="ChangeFeedProcessorBuilder"/> to use.</returns>
-        public ChangeFeedProcessorBuilder WithFeedDocumentClient(DocumentClient feedDocumentClient)
+        public ChangeFeedProcessorBuilder WithFeedDocumentClient(IDocumentClient feedDocumentClient)
         {
             if (feedDocumentClient == null) throw new ArgumentNullException(nameof(feedDocumentClient));
             this.feedDocumentClient = new ChangeFeedDocumentClient(feedDocumentClient);
@@ -261,11 +261,11 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor
         }
 
         /// <summary>
-        /// Sets an existing <see cref="DocumentClient"/> to be used to read from the leases collection.
+        /// Sets an existing <see cref="IDocumentClient"/> to be used to read from the leases collection.
         /// </summary>
-        /// <param name="leaseDocumentClient">The instance of <see cref="DocumentClient"/> to use.</param>
+        /// <param name="leaseDocumentClient">The instance of <see cref="IDocumentClient"/> to use.</param>
         /// <returns>The instance of <see cref="ChangeFeedProcessorBuilder"/> to use.</returns>
-        public ChangeFeedProcessorBuilder WithLeaseDocumentClient(DocumentClient leaseDocumentClient)
+        public ChangeFeedProcessorBuilder WithLeaseDocumentClient(IDocumentClient leaseDocumentClient)
         {
             if (leaseDocumentClient == null) throw new ArgumentNullException(nameof(leaseDocumentClient));
             this.leaseDocumentClient = new ChangeFeedDocumentClient(leaseDocumentClient);

--- a/src/DocumentDB.ChangeFeedProcessor/DataAccess/ChangeFeedDocumentClient.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/DataAccess/ChangeFeedDocumentClient.cs
@@ -16,13 +16,13 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.DataAccess
     /// </summary>
     public class ChangeFeedDocumentClient : IChangeFeedDocumentClient
     {
-        private readonly DocumentClient documentClient;
+        private readonly IDocumentClient documentClient;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ChangeFeedDocumentClient"/> class.
         /// </summary>
         /// <param name="documentClient">Existing <see cref="DocumentClient"/>.</param>
-        public ChangeFeedDocumentClient(DocumentClient documentClient)
+        public ChangeFeedDocumentClient(IDocumentClient documentClient)
         {
             if (documentClient == null) throw new ArgumentNullException(nameof(documentClient));
             this.documentClient = documentClient;


### PR DESCRIPTION
Builder is using `DocumentClient` parameter in `WithFeedDocumentClient` and `WithLeaseDocumentClient` methods which makes it cumbersome to use in projects that register `IDocumentClient` in their DI. The Azure `DocumentClient` class implements `IDocumentClient`.