### PR TITLE
pass ILeaseCheckpointer to IPartitionProcessorFactory

### DIFF
--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/ChangeFeedProcessorBuilderTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/ChangeFeedProcessorBuilderTests.cs
@@ -304,6 +304,43 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests
             Assert.Equal(typeof(LeaseLostException), exception.GetType());
         }
 
+        [Fact]
+        public async Task BuildThrowsWhenBothPartitionProcessorFactoriesSpecified()
+        {
+            builder
+                .WithFeedDocumentClient(CreateMockDocumentClient())
+                .WithLeaseDocumentClient(CreateMockDocumentClient())
+                .WithObserverFactory(Mock.Of<IChangeFeedObserverFactory>())
+                .WithPartitionProcessorFactory(Mock.Of<IPartitionProcessorFactory>())
+                .WithCheckpointPartitionProcessorFactory(Mock.Of<ICheckpointPartitionProcessorFactory>());
+
+            await Assert.ThrowsAsync<ArgumentException>(async () => await builder.BuildAsync());
+        }
+
+        [Fact]
+        public async Task BuildWhenPartitionProcessorFactoriesSpecified()
+        {
+            builder
+                .WithFeedDocumentClient(CreateMockDocumentClient())
+                .WithLeaseDocumentClient(CreateMockDocumentClient())
+                .WithObserverFactory(Mock.Of<IChangeFeedObserverFactory>())
+                .WithPartitionProcessorFactory(Mock.Of<IPartitionProcessorFactory>());
+
+            await builder.BuildAsync();
+        }
+
+        [Fact]
+        public async Task BuildWhenCheckpointPartitionProcessorFactoriesSpecified()
+        {
+            builder
+                .WithFeedDocumentClient(CreateMockDocumentClient())
+                .WithLeaseDocumentClient(CreateMockDocumentClient())
+                .WithObserverFactory(Mock.Of<IChangeFeedObserverFactory>())
+                .WithCheckpointPartitionProcessorFactory(Mock.Of<ICheckpointPartitionProcessorFactory>());
+
+            await builder.BuildAsync();
+        }
+
         private void SetupBuilderForPartitionedLeaseCollection(string partitionKey)
         {
             var partitionedCollection = MockHelpers.CreateCollection(

--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/FeedProcessor/PartitionProcessorFactoryTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/FeedProcessor/PartitionProcessorFactoryTests.cs
@@ -52,8 +52,8 @@
                 .Returns(leaseContinuationToken);
 
             var healthMonitor = Mock.Of<IHealthMonitor>();
-            PartitionProcessorFactory sut = new PartitionProcessorFactory(this.docClient, hostOptions, leaseCheckpointer, this.collectionSelfLink, healthMonitor);
-            var processor = sut.Create(lease, this.observer);
+            PartitionProcessorFactory sut = new PartitionProcessorFactory(this.docClient, hostOptions, this.collectionSelfLink, healthMonitor);
+            var processor = sut.Create(lease, leaseCheckpointer, this.observer);
 
             Mock.Get(this.docClient)
                 .Verify(d => d.CreateDocumentChangeFeedQuery(

--- a/src/DocumentDB.ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
@@ -521,15 +521,20 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor
 
         private ICheckpointPartitionProcessorFactory GetPartitionProcessorFactory(string feedCollectionSelfLink)
         {
+            ICheckpointPartitionProcessorFactory factory = this.checkpointPartitionProcessorFactory;
             if (this.partitionProcessorFactory != null)
             {
                 if (this.checkpointPartitionProcessorFactory != null)
                     throw new ArgumentException("Only one partition processor factory can be used");
 
-                this.checkpointPartitionProcessorFactory = new CheckpointPartitionProcessorFactoryAdapter(this.partitionProcessorFactory);
+                factory = new CheckpointPartitionProcessorFactoryAdapter(this.partitionProcessorFactory);
             }
 
-            return this.checkpointPartitionProcessorFactory ?? new PartitionProcessorFactory(this.feedDocumentClient, this.changeFeedProcessorOptions, feedCollectionSelfLink, this.healthMonitor);
+            return factory ?? new PartitionProcessorFactory(
+                       this.feedDocumentClient,
+                       this.changeFeedProcessorOptions,
+                       feedCollectionSelfLink,
+                       this.healthMonitor);
         }
     }
 }

--- a/src/DocumentDB.ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
@@ -420,10 +420,11 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor
                 this.changeFeedProcessorOptions.DegreeOfParallelism,
                 this.changeFeedProcessorOptions.QueryPartitionsMaxBatchSize);
             var bootstrapper = new Bootstrapper(synchronizer, leaseStoreManager, this.lockTime, this.sleepTime);
-            var partitionSuperviserFactory = new PartitionSupervisorFactory(
+            var partitionSupervisorFactory = new PartitionSupervisorFactory(
                 factory,
                 leaseStoreManager,
-                this.partitionProcessorFactory ?? new PartitionProcessorFactory(this.feedDocumentClient, this.changeFeedProcessorOptions, leaseStoreManager, feedCollectionSelfLink, this.healthMonitor),
+                leaseStoreManager,
+                this.partitionProcessorFactory ?? new PartitionProcessorFactory(this.feedDocumentClient, this.changeFeedProcessorOptions, feedCollectionSelfLink, this.healthMonitor),
                 this.changeFeedProcessorOptions);
 
             if (this.loadBalancingStrategy == null)
@@ -435,7 +436,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor
                     this.changeFeedProcessorOptions.LeaseExpirationInterval);
             }
 
-            IPartitionController partitionController = new PartitionController(leaseStoreManager, leaseStoreManager, partitionSuperviserFactory, synchronizer);
+            IPartitionController partitionController = new PartitionController(leaseStoreManager, leaseStoreManager, partitionSupervisorFactory, synchronizer);
             partitionController = new HealthMonitoringPartitionControllerDecorator(partitionController, this.healthMonitor);
             var partitionLoadBalancer = new PartitionLoadBalancer(
                 partitionController,

--- a/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/Adapters/CheckpointPartitionProcessorFactoryAdapter.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/Adapters/CheckpointPartitionProcessorFactoryAdapter.cs
@@ -1,0 +1,24 @@
+﻿//----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  Licensed under the MIT license.
+//----------------------------------------------------------------
+
+namespace Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing.Adapters
+{
+    using Microsoft.Azure.Documents.ChangeFeedProcessor.LeaseManagement;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement;
+
+    internal class CheckpointPartitionProcessorFactoryAdapter : ICheckpointPartitionProcessorFactory
+    {
+        private readonly IPartitionProcessorFactory partitionProcessorFactory;
+
+        public CheckpointPartitionProcessorFactoryAdapter(IPartitionProcessorFactory partitionProcessorFactory)
+        {
+            this.partitionProcessorFactory = partitionProcessorFactory;
+        }
+
+        public IPartitionProcessor Create(ILease lease, ILeaseCheckpointer leaseCheckpointer, IChangeFeedObserver observer)
+        {
+            return this.partitionProcessorFactory.Create(lease, observer);
+        }
+    }
+}

--- a/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/ICheckpointPartitionProcessorFactory.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/ICheckpointPartitionProcessorFactory.cs
@@ -4,19 +4,21 @@
 
 namespace Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing
 {
+    using Microsoft.Azure.Documents.ChangeFeedProcessor.LeaseManagement;
     using Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement;
 
     /// <summary>
-    /// Factory class used to create instance(s) of <see cref="IPartitionProcessor"/>. Use <see cref="ICheckpointPartitionProcessorFactory"/> for using default checkpoint mechanism.
+    /// Factory class used to create instance(s) of <see cref="IPartitionProcessor"/> and allows to re-use default checkpoint mechanism.
     /// </summary>
-    public interface IPartitionProcessorFactory
+    public interface ICheckpointPartitionProcessorFactory
     {
         /// <summary>
         /// Creates an instance of a <see cref="IPartitionProcessor"/>.
         /// </summary>
         /// <param name="lease">Lease to be used for partition processing</param>
+        /// <param name="leaseCheckpointer">Default lease checkpointer</param>
         /// <param name="observer">Observer to be used</param>
         /// <returns>An instance of a <see cref="IPartitionProcessor"/>.</returns>
-        IPartitionProcessor Create(ILease lease, IChangeFeedObserver observer);
+        IPartitionProcessor Create(ILease lease, ILeaseCheckpointer leaseCheckpointer, IChangeFeedObserver observer);
     }
 }

--- a/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/IPartitionProcessor.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/IPartitionProcessor.cs
@@ -8,8 +8,8 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing
     using System.Threading.Tasks;
 
     /// <summary>
-    /// Provides an API to run continious processing on a single partition of some resource.
-    /// Created by <see cref="IPartitionProcessorFactory.Create"/> after some lease is acquired by the current host.
+    /// Provides an API to run continuous processing on a single partition of some resource.
+    /// Created by <see cref="IPartitionProcessorFactory.Create"/> or <see cref="ICheckpointPartitionProcessorFactory.Create"/> after some lease is acquired by the current host.
     /// Processing can perform the following tasks in a loop:
     ///   1. Read some data from the resource partition.
     ///   2. Handle possible problems with the read.

--- a/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/IPartitionProcessorFactory.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/IPartitionProcessorFactory.cs
@@ -4,6 +4,7 @@
 
 namespace Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing
 {
+    using Microsoft.Azure.Documents.ChangeFeedProcessor.LeaseManagement;
     using Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement;
 
     /// <summary>
@@ -15,8 +16,9 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing
         /// Creates an instance of a <see cref="IPartitionProcessor"/>.
         /// </summary>
         /// <param name="lease">Lease to be used for partition processing</param>
+        /// <param name="leaseCheckpointer">Default lease checkpointer</param>
         /// <param name="observer">Observer to be used</param>
         /// <returns>An instance of a <see cref="IPartitionProcessor"/>.</returns>
-        IPartitionProcessor Create(ILease lease, IChangeFeedObserver observer);
+        IPartitionProcessor Create(ILease lease, ILeaseCheckpointer leaseCheckpointer, IChangeFeedObserver observer);
     }
 }

--- a/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/PartitionProcessorFactory.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/PartitionProcessorFactory.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing
     using Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement;
     using Microsoft.Azure.Documents.Client;
 
-    internal class PartitionProcessorFactory : IPartitionProcessorFactory
+    internal class PartitionProcessorFactory : ICheckpointPartitionProcessorFactory
     {
         private readonly IChangeFeedDocumentClient documentClient;
         private readonly ChangeFeedProcessorOptions changeFeedProcessorOptions;

--- a/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/PartitionProcessorFactory.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/PartitionProcessorFactory.cs
@@ -15,34 +15,31 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing
     {
         private readonly IChangeFeedDocumentClient documentClient;
         private readonly ChangeFeedProcessorOptions changeFeedProcessorOptions;
-        private readonly ILeaseCheckpointer leaseCheckpointer;
         private readonly string collectionSelfLink;
         private readonly IHealthMonitor healthMonitor;
 
         public PartitionProcessorFactory(
             IChangeFeedDocumentClient documentClient,
             ChangeFeedProcessorOptions changeFeedProcessorOptions,
-            ILeaseCheckpointer leaseCheckpointer,
             string collectionSelfLink,
             IHealthMonitor healthMonitor)
         {
             if (documentClient == null) throw new ArgumentNullException(nameof(documentClient));
             if (changeFeedProcessorOptions == null) throw new ArgumentNullException(nameof(changeFeedProcessorOptions));
-            if (leaseCheckpointer == null) throw new ArgumentNullException(nameof(leaseCheckpointer));
             if (collectionSelfLink == null) throw new ArgumentNullException(nameof(collectionSelfLink));
             if (healthMonitor == null) throw new ArgumentNullException(nameof(healthMonitor));
 
             this.documentClient = documentClient;
             this.changeFeedProcessorOptions = changeFeedProcessorOptions;
-            this.leaseCheckpointer = leaseCheckpointer;
             this.collectionSelfLink = collectionSelfLink;
             this.healthMonitor = healthMonitor;
         }
 
-        public IPartitionProcessor Create(ILease lease, IChangeFeedObserver observer)
+        public IPartitionProcessor Create(ILease lease, ILeaseCheckpointer leaseCheckpointer, IChangeFeedObserver observer)
         {
             if (observer == null) throw new ArgumentNullException(nameof(observer));
             if (lease == null) throw new ArgumentNullException(nameof(lease));
+            if (leaseCheckpointer == null) throw new ArgumentNullException(nameof(leaseCheckpointer));
 
             var settings = new ProcessorSettings
             {
@@ -58,7 +55,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing
                 SessionToken = this.changeFeedProcessorOptions.SessionToken,
             };
 
-            var checkpointer = new PartitionCheckpointer(this.leaseCheckpointer, lease);
+            var checkpointer = new PartitionCheckpointer(leaseCheckpointer, lease);
 
             var changeFeedOptions = new ChangeFeedOptions
             {

--- a/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/PartitionSupervisorFactory.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/PartitionSupervisorFactory.cs
@@ -14,13 +14,13 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement
         private readonly ILeaseManager leaseManager;
         private readonly ILeaseCheckpointer leaseCheckpointer;
         private readonly ChangeFeedProcessorOptions changeFeedProcessorOptions;
-        private readonly IPartitionProcessorFactory partitionProcessorFactory;
+        private readonly ICheckpointPartitionProcessorFactory partitionProcessorFactory;
 
         public PartitionSupervisorFactory(
             IChangeFeedObserverFactory observerFactory,
             ILeaseManager leaseManager,
             ILeaseCheckpointer leaseCheckpointer,
-            IPartitionProcessorFactory partitionProcessorFactory,
+            ICheckpointPartitionProcessorFactory partitionProcessorFactory,
             ChangeFeedProcessorOptions options)
         {
             if (observerFactory == null) throw new ArgumentNullException(nameof(observerFactory));

--- a/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/PartitionSupervisorFactory.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/PartitionSupervisorFactory.cs
@@ -12,22 +12,26 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement
     {
         private readonly IChangeFeedObserverFactory observerFactory;
         private readonly ILeaseManager leaseManager;
+        private readonly ILeaseCheckpointer leaseCheckpointer;
         private readonly ChangeFeedProcessorOptions changeFeedProcessorOptions;
         private readonly IPartitionProcessorFactory partitionProcessorFactory;
 
         public PartitionSupervisorFactory(
             IChangeFeedObserverFactory observerFactory,
             ILeaseManager leaseManager,
+            ILeaseCheckpointer leaseCheckpointer,
             IPartitionProcessorFactory partitionProcessorFactory,
             ChangeFeedProcessorOptions options)
         {
             if (observerFactory == null) throw new ArgumentNullException(nameof(observerFactory));
             if (leaseManager == null) throw new ArgumentNullException(nameof(leaseManager));
+            if (leaseCheckpointer == null) throw new ArgumentNullException(nameof(leaseCheckpointer));
             if (options == null) throw new ArgumentNullException(nameof(options));
             if (partitionProcessorFactory == null) throw new ArgumentNullException(nameof(partitionProcessorFactory));
 
             this.observerFactory = observerFactory;
             this.leaseManager = leaseManager;
+            this.leaseCheckpointer = leaseCheckpointer;
             this.changeFeedProcessorOptions = options;
             this.partitionProcessorFactory = partitionProcessorFactory;
         }
@@ -38,7 +42,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement
                 throw new ArgumentNullException(nameof(lease));
 
             IChangeFeedObserver changeFeedObserver = this.observerFactory.CreateObserver();
-            var processor = this.partitionProcessorFactory.Create(lease, changeFeedObserver);
+            var processor = this.partitionProcessorFactory.Create(lease, this.leaseCheckpointer, changeFeedObserver);
             var renewer = new LeaseRenewer(lease, this.leaseManager, this.changeFeedProcessorOptions.LeaseRenewInterval);
 
             return new PartitionSupervisor(lease, changeFeedObserver, processor, renewer);


### PR DESCRIPTION
This PR introduces the functionality for re-using the default checkpoint mechanism for a custom `IPartitionProcessor` implementation. It can be used if the custom processor requires continuation tokens to be written in leases.

The proposed changes introduce new `ICheckpointPartitionProcessorFactory` interface:
`IPartitionProcessor Create(ILease lease, ILeaseCheckpointer leaseCheckpointer, IChangeFeedObserver observer)`