### PR TITLE
Fixes for 2 known cases when observer is closed with Unknown reason

### DIFF
--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/Exceptions/PartitionExceptionsTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/Exceptions/PartitionExceptionsTests.cs
@@ -120,28 +120,11 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.Exceptions
         }
 
         [Fact]
-        public async Task Run_ShouldThrowReadSessionNotAvailable()
+        public async Task Run_ShouldRethrowReadSessionNotAvailable()
         {
             Mock.Get(documentQuery)
                 .SetupSequence(query => query.ExecuteNextAsync<Document>(It.Is<CancellationToken>(token => token == cancellationTokenSource.Token)))
-                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
-                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
-                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
-                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
-                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
-                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
-                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
-                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
-                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
-                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
-                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
-                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
-                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
-                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
-                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
-                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
-                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
-                .ReturnsAsync(feedResponse);
+                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable));
 
             Exception exception = await Record.ExceptionAsync(() => partitionProcessor.RunAsync(cancellationTokenSource.Token));
             Assert.IsAssignableFrom<ReadSessionNotAvailableException>(exception);

--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/Exceptions/PartitionExceptionsTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/Exceptions/PartitionExceptionsTests.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.Exceptions
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Documents.ChangeFeedProcessor.DataAccess;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor.DocDBErrors;
     using Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions;
     using Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing;
     using Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.Utils;
@@ -119,15 +120,31 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.Exceptions
         }
 
         [Fact]
-        public async Task Run_ShouldReThrow_IfUnknownNotFoundSubcode()
+        public async Task Run_ShouldThrowReadSessionNotAvailable()
         {
             Mock.Get(documentQuery)
                 .SetupSequence(query => query.ExecuteNextAsync<Document>(It.Is<CancellationToken>(token => token == cancellationTokenSource.Token)))
-                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", 1002))
+                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
+                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
+                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
+                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
+                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
+                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
+                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
+                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
+                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
+                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
+                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
+                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
+                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
+                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
+                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
+                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
+                .Throws(DocumentExceptionHelpers.CreateException("Microsoft.Azure.Documents.NotFoundException", (int)SubStatusCode.ReadSessionNotAvailable))
                 .ReturnsAsync(feedResponse);
 
             Exception exception = await Record.ExceptionAsync(() => partitionProcessor.RunAsync(cancellationTokenSource.Token));
-            Assert.IsAssignableFrom<DocumentClientException>(exception);
+            Assert.IsAssignableFrom<ReadSessionNotAvailableException>(exception);
         }
 
         [Fact]

--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/FeedProcessor/PartitionProcessorTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/FeedProcessor/PartitionProcessorTests.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.FeedProcessor
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Documents.ChangeFeedProcessor.DataAccess;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor.DocDBErrors;
     using Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions;
     using Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing;
     using Microsoft.Azure.Documents.ChangeFeedProcessor.Monitoring;
@@ -66,7 +67,12 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.FeedProcessor
 
             observer = Mock.Of<IChangeFeedObserver>();
             var checkPointer = new Mock<IPartitionCheckpointer>();
-            sut = new PartitionProcessor(new ObserverExceptionWrappingChangeFeedObserverDecorator(observer), documentQuery, new ChangeFeedOptions(), processorSettings, checkPointer.Object);
+            sut = new PartitionProcessor(
+                new ObserverExceptionWrappingChangeFeedObserverDecorator(observer),
+                documentQuery,
+                new ChangeFeedOptions(),
+                processorSettings,
+                checkPointer.Object);
         }
 
         [Fact]
@@ -314,6 +320,34 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.FeedProcessor
                     Times.Exactly(3));
 
             Assert.Equal("token.token2.token3.", accumulator);
+        }
+
+        [Fact]
+        public async Task Run_ShoulRetry_OnSinglePartitionNotFoundWithReadSessionNotAvailableException()
+        {
+            Mock.Get(documentQuery)
+                .Reset();
+
+            Exception readSessionNotAvaialbeException = DocumentExceptionHelpers.CreateException(
+                "Microsoft.Azure.Documents.NotFoundException",
+                (int)SubStatusCode.ReadSessionNotAvailable,
+                "throw in test");
+
+            Mock.Get(documentQuery)
+                .SetupSequence(query => query.ExecuteNextAsync<Document>(It.Is<CancellationToken>(token => token == cancellationTokenSource.Token)))
+                .Throws(readSessionNotAvaialbeException)
+                .ReturnsAsync(feedResponse);
+
+            Mock.Get(observer)
+                .Setup(feedObserver => feedObserver
+                    .ProcessChangesAsync(It.IsAny<IChangeFeedObserverContext>(), It.IsAny<IReadOnlyList<Document>>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask)
+                .Callback(cancellationTokenSource.Cancel);
+
+            await Assert.ThrowsAsync<TaskCanceledException>(() => sut.RunAsync(cancellationTokenSource.Token));
+
+            Mock.Get(documentQuery)
+                .Verify(query => query.ExecuteNextAsync<Document>(It.Is<CancellationToken>(token => token == cancellationTokenSource.Token)), Times.Exactly(2));
         }
 
         private class CustomException : Exception

--- a/src/DocumentDB.ChangeFeedProcessor.UnitTests/PartitionManagement/PartitionSupervisorTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.UnitTests/PartitionManagement/PartitionSupervisorTests.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.UnitTests.PartitionManag
         }
 
         [Fact]
-        public async Task RunObserver_ResourceGoneCloseReason_IfProcessorFailedWithReadSessionNotAvailableException()
+        public async Task RunObserver_ReadSessionNotAvailableCloseReason_IfProcessorFailedWithReadSessionNotAvailableException()
         {
             Mock.Get(partitionProcessor)
                 .Setup(processor => processor.RunAsync(It.IsAny<CancellationToken>()))

--- a/src/DocumentDB.ChangeFeedProcessor/DocDBErrors/DocDbError.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/DocDBErrors/DocDbError.cs
@@ -11,5 +11,6 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.DocDBErrors
         PartitionSplit,
         TransientError,
         MaxItemCountTooLarge,
+        ReadSessionNotAvailable,
     }
 }

--- a/src/DocumentDB.ChangeFeedProcessor/DocDBErrors/ExceptionClassifier.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/DocDBErrors/ExceptionClassifier.cs
@@ -13,8 +13,10 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.DocDBErrors
         {
             SubStatusCode subStatusCode = clientException.GetSubStatusCode();
 
-            if (clientException.StatusCode == HttpStatusCode.NotFound && subStatusCode != SubStatusCode.ReadSessionNotAvailable)
-                return DocDbError.PartitionNotFound;
+            if (clientException.StatusCode == HttpStatusCode.NotFound)
+            {
+                return subStatusCode == SubStatusCode.ReadSessionNotAvailable ? DocDbError.ReadSessionNotAvailable : DocDbError.PartitionNotFound;
+            }
 
             if (clientException.StatusCode == HttpStatusCode.Gone && (subStatusCode == SubStatusCode.PartitionKeyRangeGone || subStatusCode == SubStatusCode.Splitting))
                 return DocDbError.PartitionSplit;

--- a/src/DocumentDB.ChangeFeedProcessor/DocumentDB.ChangeFeedProcessor.csproj
+++ b/src/DocumentDB.ChangeFeedProcessor/DocumentDB.ChangeFeedProcessor.csproj
@@ -21,7 +21,7 @@
     <AssemblyName>Microsoft.Azure.Documents.ChangeFeedProcessor</AssemblyName>
 
     <PackageId>Microsoft.Azure.DocumentDB.ChangeFeedProcessor</PackageId>
-    <PackageVersion>2.3.0</PackageVersion>
+    <PackageVersion>2.3.1</PackageVersion>
     <Title>Microsoft Azure Cosmos DB Change Feed Processor library</Title>
     <Authors>Microsoft</Authors>
     <PackageLicenseUrl>http://go.microsoft.com/fwlink/?LinkID=509837</PackageLicenseUrl>
@@ -44,9 +44,9 @@
     <!--CS1587:XML comment is not placed on a valid language element 
     LibLog files have misplaced comments, but we cannot touch them.-->
     <NoWarn>1587</NoWarn>
-    <Version>2.3.0</Version>
-    <AssemblyVersion>2.3.0.0</AssemblyVersion>
-    <FileVersion>2.3.0.0</FileVersion>
+    <Version>2.3.1</Version>
+    <AssemblyVersion>2.3.1.0</AssemblyVersion>
+    <FileVersion>2.3.1.0</FileVersion>
     <PackageReleaseNotes>The change log for this project is available at https://docs.microsoft.com/azure/cosmos-db/sql-api-sdk-dotnet-changefeed.
 </PackageReleaseNotes>
   </PropertyGroup>

--- a/src/DocumentDB.ChangeFeedProcessor/Exceptions/ReadSessionNotAvailableException.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Exceptions/ReadSessionNotAvailableException.cs
@@ -1,0 +1,49 @@
+﻿//----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  Licensed under the MIT license.
+//----------------------------------------------------------------
+
+namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Exceptions
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Runtime.Serialization;
+    using System.Text;
+
+    /// <summary>
+    /// Exception occurred when all retries on StatusCode.NotFound/SubStatusCode.ReadSessionNotAvaialable are over.
+    /// </summary>
+    [Serializable]
+    public class ReadSessionNotAvailableException : PartitionException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReadSessionNotAvailableException"/> class using error message and last continuation token.
+        /// </summary>
+        /// <param name="message">The exception error message.</param>
+        /// <param name="lastContinuation"> Request continuation token.</param>
+        public ReadSessionNotAvailableException(string message, string lastContinuation)
+            : base(message, lastContinuation)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReadSessionNotAvailableException" /> class using error message and inner exception.
+        /// </summary>
+        /// <param name="message">The exception error message.</param>
+        /// <param name="lastContinuation">The last known continuation token</param>
+        /// <param name="innerException">The inner exception.</param>
+        public ReadSessionNotAvailableException(string message, string lastContinuation, Exception innerException)
+            : base(message, lastContinuation, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReadSessionNotAvailableException" /> class using default values.
+        /// </summary>
+        /// <param name="info">The SerializationInfo object that holds serialized object data for the exception being thrown.</param>
+        /// <param name="context">The StreamingContext that contains contextual information about the source or destination.</param>
+        protected ReadSessionNotAvailableException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/ChangeFeedObserverCloseReason.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/ChangeFeedObserverCloseReason.cs
@@ -40,7 +40,8 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing
         LeaseGone,
 
         /// <summary>
-        /// Indicates a warning of "read session not avaialbe". Note: SDK retries on this error.
+        /// Indicates a "read session not available" warning related to <see cref="Microsoft.Azure.Documents.ConsistencyLevel.Session"/>.
+        /// Note: SDK retries on this error.
         /// </summary>
         ReadSessionNotAvailable,
     }

--- a/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/ChangeFeedObserverCloseReason.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/ChangeFeedObserverCloseReason.cs
@@ -38,5 +38,10 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing
         /// The lease is gone. This can be due to partition split.
         /// </summary>
         LeaseGone,
+
+        /// <summary>
+        /// Indicates a warning of multiple hits of "read session not avaialbe".
+        /// </summary>
+        ReadSessionNotAvailable,
     }
 }

--- a/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/ChangeFeedObserverCloseReason.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/ChangeFeedObserverCloseReason.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing
         LeaseGone,
 
         /// <summary>
-        /// Indicates a warning of multiple hits of "read session not avaialbe".
+        /// Indicates a warning of "read session not avaialbe". Note: SDK retries on this error.
         /// </summary>
         ReadSessionNotAvailable,
     }

--- a/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/PartitionProcessor.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/FeedProcessing/PartitionProcessor.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing
     internal class PartitionProcessor : IPartitionProcessor
     {
         private static readonly int DefaultMaxItemCount = 100;
+        private static readonly int MaxReadSessionNotAvailableHits = 16;
         private readonly ILog logger = LogProvider.GetCurrentClassLogger();
         private readonly IChangeFeedDocumentQuery<Document> query;
         private readonly ProcessorSettings settings;
@@ -38,6 +39,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing
         public async Task RunAsync(CancellationToken cancellationToken)
         {
             string lastContinuation = this.settings.StartContinuation;
+            int readSessionNotAvailableHitCount = 0;
 
             while (!cancellationToken.IsCancellationRequested)
             {
@@ -49,6 +51,12 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing
                     {
                         IFeedResponse<Document> response = await this.query.ExecuteNextAsync<Document>(cancellationToken).ConfigureAwait(false);
                         lastContinuation = response.ResponseContinuation;
+
+                        if (readSessionNotAvailableHitCount > 0)
+                        {
+                            readSessionNotAvailableHitCount = 0; // Reset on success.
+                        }
+
                         if (response.Count > 0)
                         {
                             await this.DispatchChanges(response, cancellationToken).ConfigureAwait(false);
@@ -69,13 +77,27 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing
                     {
                         case DocDbError.PartitionNotFound:
                             throw new PartitionNotFoundException("Partition not found.", lastContinuation);
+
+                        case DocDbError.ReadSessionNotAvailable:
+                            if (++readSessionNotAvailableHitCount > MaxReadSessionNotAvailableHits)
+                            {
+                                throw new ReadSessionNotAvailableException("Read session not availalbe.", lastContinuation);
+                            }
+
+                            this.logger.WarnFormat("ReadSessionNotAvailableHits: {0} hits of {1} MAX.", readSessionNotAvailableHitCount, MaxReadSessionNotAvailableHits);
+                            delay = TimeSpan.Zero;
+                            break;  // Retry, transient NotFound/ReadSessionNotAvailable.
+
                         case DocDbError.PartitionSplit:
                             throw new PartitionSplitException("Partition split.", lastContinuation);
+
                         case DocDbError.Undefined:
                             throw;
+
                         case DocDbError.TransientError:
                             // Retry on transient (429) errors
                             break;
+
                         case DocDbError.MaxItemCountTooLarge:
                             if (!this.options.MaxItemCount.HasValue)
                             {
@@ -90,6 +112,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing
                             this.options.MaxItemCount /= 2;
                             this.logger.WarnFormat("Reducing maxItemCount, new value: {0}.", this.options.MaxItemCount);
                             break;
+
                         default:
                             this.logger.Fatal($"Unrecognized DocDbError enum value {docDbError}");
                             Debug.Fail($"Unrecognized DocDbError enum value {docDbError}");
@@ -97,7 +120,9 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing
                     }
 
                     if (clientException.RetryAfter != TimeSpan.Zero)
+                    {
                         delay = clientException.RetryAfter;
+                    }
                 }
                 catch (TaskCanceledException canceledException)
                 {

--- a/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/PartitionSupervisor.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/PartitionManagement/PartitionSupervisor.cs
@@ -59,6 +59,16 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement
                 closeReason = ChangeFeedObserverCloseReason.LeaseGone;
                 throw;
             }
+            catch (PartitionNotFoundException)
+            {
+                closeReason = ChangeFeedObserverCloseReason.ResourceGone;
+                throw;
+            }
+            catch (ReadSessionNotAvailableException)
+            {
+                closeReason = ChangeFeedObserverCloseReason.ReadSessionNotAvailable;
+                throw;
+            }
             catch (OperationCanceledException) when (shutdownToken.IsCancellationRequested)
             {
                 closeReason = ChangeFeedObserverCloseReason.Shutdown;

--- a/src/DocumentDB.ChangeFeedProcessor/Utils/DocumentCollectionHelper.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Utils/DocumentCollectionHelper.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Utils
 
     internal static class DocumentCollectionHelper
     {
-        private const string DefaultUserAgentSuffix = "changefeed-2.3.0";
+        private const string DefaultUserAgentSuffix = "changefeed-2.3.1";
 
         public static DocumentCollectionInfo Canonicalize(this DocumentCollectionInfo collectionInfo)
         {


### PR DESCRIPTION
For known scenarios we should not close the observer with Unknown close reason.
In this this change:
- When PartitionNotFoundException is thrown, close the observer with ResourceGone reason.
- Also when SDK throws exception with 404/1002 (read session not available) classify error as new classifier ReadSessionNotAvailable, add new exception for that and close the observer with ReadSessionNotAvailable.