### PR TITLE
Change Feed Processor V3 compatibility

### DIFF
--- a/src/DocumentDB.ChangeFeedProcessor.IntegrationTests/V3CompatibilityTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.IntegrationTests/V3CompatibilityTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.IntegrationTests
                     .BuildAsync();
 
             await changeFeedProcessorBuilder.StartAsync();
-            await Task.Delay(5000);
+            await Task.Delay(10000);
 
             // Inserting some documents
             using (DocumentClient client = new DocumentClient(this.MonitoredCollectionInfo.Uri, this.MonitoredCollectionInfo.MasterKey, this.MonitoredCollectionInfo.ConnectionPolicy))
@@ -110,7 +110,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.IntegrationTests
             }
 
             // Waiting on all notifications to finish
-            await Task.Delay(5000);
+            await Task.Delay(10000);
             await changeFeedProcessorBuilder.StopAsync();
 
             // At this point we have leases for V2, so we will simulate V3 by manually adding LeaseToken and removing PartitionId
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.IntegrationTests
                     .WithLeaseCollection(this.LeaseCollectionInfo)
                     .BuildAsync();
             await changeFeedProcessorBuilder.StartAsync();
-            await Task.Delay(5000);
+            await Task.Delay(10000);
 
             // Now all leases are V2 leases, create the rest of the documents
             using (DocumentClient client = new DocumentClient(this.MonitoredCollectionInfo.Uri, this.MonitoredCollectionInfo.MasterKey, this.MonitoredCollectionInfo.ConnectionPolicy))
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.IntegrationTests
             }
 
             // Waiting on all notifications to finish, should be using LeaseToken from the V3 lease
-            await Task.Delay(5000);
+            await Task.Delay(10000);
             await changeFeedProcessorBuilder.StopAsync();
 
             // Verify we processed all items (including when using the V3 leases)

--- a/src/DocumentDB.ChangeFeedProcessor.IntegrationTests/V3CompatibilityTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.IntegrationTests/V3CompatibilityTests.cs
@@ -179,21 +179,20 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.IntegrationTests
             {
                 Uri collectionUri = UriFactory.CreateDocumentCollectionUri(this.LeaseCollectionInfo.DatabaseName, this.LeaseCollectionInfo.CollectionName);
 
-                IDocumentQuery<dynamic> query = client.CreateDocumentQuery<dynamic>(collectionUri, "SELECT * FROM c").AsDocumentQuery();
+                IDocumentQuery<JObject> query = client.CreateDocumentQuery<JObject>(collectionUri, "SELECT * FROM c").AsDocumentQuery();
                 while (query.HasMoreResults)
                 {
-                    foreach (dynamic lease in await query.ExecuteNextAsync())
+                    foreach (JObject lease in await query.ExecuteNextAsync())
                     {
-                        string leaseId = lease.id;
+                        string leaseId = lease.Value<string>("id");
                         if (leaseId.Contains(".info") || leaseId.Contains(".lock"))
                         {
                             // These are the store initialization marks
                             continue;
                         }
 
-                        Assert.NotNull(lease.LeaseToken);
-                        Assert.NotNull(lease.PartitionId);
-                        Assert.Equal(lease.LeaseToken, lease.PartitionId);
+                        Assert.NotNull(lease.Value<string>("PartitionId"));
+                        Assert.Null(lease.Value<string>("LeaseToken"));
                     }
                 }
             }

--- a/src/DocumentDB.ChangeFeedProcessor.IntegrationTests/V3CompatibilityTests.cs
+++ b/src/DocumentDB.ChangeFeedProcessor.IntegrationTests/V3CompatibilityTests.cs
@@ -1,0 +1,221 @@
+﻿//----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  Licensed under the MIT license.
+//----------------------------------------------------------------
+
+namespace Microsoft.Azure.Documents.ChangeFeedProcessor.IntegrationTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor.IntegrationTests.Utils;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement;
+    using Microsoft.Azure.Documents.Client;
+    using Microsoft.Azure.Documents.Linq;
+    using Newtonsoft.Json.Linq;
+    using Xunit;
+
+    [Trait("Category", "Integration")]
+    [Collection("Integration tests")]
+    public class V3CompatibilityTests : IntegrationTest
+    {
+        public V3CompatibilityTests() : base()
+        {
+        }
+
+        [Fact]
+        public async Task Schema_DefaultsToNoLeaseToken()
+        {
+            TestObserverFactory observerFactory = new TestObserverFactory(
+                (FeedProcessing.IChangeFeedObserverContext context, IReadOnlyList<Document> docs) =>
+                {
+                    return Task.CompletedTask;
+                });
+
+            IChangeFeedProcessor changeFeedProcessorBuilder = await new ChangeFeedProcessorBuilder()
+                    .WithObserverFactory(observerFactory)
+                    .WithHostName("smoke_test")
+                    .WithFeedCollection(this.MonitoredCollectionInfo)
+                    .WithLeaseCollection(this.LeaseCollectionInfo)
+                    .BuildAsync();
+
+            await changeFeedProcessorBuilder.StartAsync();
+            await Task.Delay(5000);
+            await changeFeedProcessorBuilder.StopAsync();
+
+            // Verify that no leases have LeaseToken (V3 contract)
+            using (DocumentClient client = new DocumentClient(this.LeaseCollectionInfo.Uri, this.LeaseCollectionInfo.MasterKey, this.LeaseCollectionInfo.ConnectionPolicy))
+            {
+                Uri collectionUri = UriFactory.CreateDocumentCollectionUri(this.LeaseCollectionInfo.DatabaseName, this.LeaseCollectionInfo.CollectionName);
+
+                IDocumentQuery<JObject> query = client.CreateDocumentQuery<JObject>(collectionUri, "SELECT * FROM c").AsDocumentQuery();
+                while (query.HasMoreResults)
+                {
+                    foreach (JObject lease in await query.ExecuteNextAsync())
+                    {
+                        string leaseId = lease.Value<string>("id");
+                        if (leaseId.Contains(".info") || leaseId.Contains(".lock"))
+                        {
+                            // These are the store initialization marks
+                            continue;
+                        }
+
+                        Assert.NotNull(lease.Value<string>("PartitionId"));
+                        Assert.Null(lease.Value<string>("LeaseToken"));
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// When the user migrates from V3 CFP, the leases contain LeaseToken.
+        /// To allow for backward compatibility (V2 -> V3 -> V2) we need to honor the existence of LeaseToken and maintain its value in case the lease was created by V3.
+        /// </summary>
+        [Fact]
+        public async Task Schema_OnV2MigrationMaintainLeaseToken()
+        {
+            List<int> expectedIds = Enumerable.Range(0, 20).ToList();
+            List<int> receivedIds = new List<int>();
+            TestObserverFactory observerFactory = new TestObserverFactory(
+                (FeedProcessing.IChangeFeedObserverContext context, IReadOnlyList<Document> docs) =>
+                {
+                    foreach (Document doc in docs)
+                    {
+                        receivedIds.Add(int.Parse(doc.Id));
+                    }
+
+                    return Task.CompletedTask;
+                });
+
+            IChangeFeedProcessor changeFeedProcessorBuilder = await new ChangeFeedProcessorBuilder()
+                    .WithObserverFactory(observerFactory)
+                    .WithHostName("smoke_test")
+                    .WithFeedCollection(this.MonitoredCollectionInfo)
+                    .WithLeaseCollection(this.LeaseCollectionInfo)
+                    .BuildAsync();
+
+            await changeFeedProcessorBuilder.StartAsync();
+            await Task.Delay(5000);
+
+            // Inserting some documents
+            using (DocumentClient client = new DocumentClient(this.MonitoredCollectionInfo.Uri, this.MonitoredCollectionInfo.MasterKey, this.MonitoredCollectionInfo.ConnectionPolicy))
+            {
+                Uri collectionUri = UriFactory.CreateDocumentCollectionUri(this.MonitoredCollectionInfo.DatabaseName, this.MonitoredCollectionInfo.CollectionName);
+
+                foreach (int id in expectedIds.Take(10))
+                {
+                    await client.CreateDocumentAsync(collectionUri, new { id = id.ToString() });
+                }
+            }
+
+            // Waiting on all notifications to finish
+            await Task.Delay(5000);
+            await changeFeedProcessorBuilder.StopAsync();
+
+            // At this point we have leases for V2, so we will simulate V3 by manually adding LeaseToken and removing PartitionId
+            using (DocumentClient client = new DocumentClient(this.LeaseCollectionInfo.Uri, this.LeaseCollectionInfo.MasterKey, this.LeaseCollectionInfo.ConnectionPolicy))
+            {
+                Uri collectionUri = UriFactory.CreateDocumentCollectionUri(this.LeaseCollectionInfo.DatabaseName, this.LeaseCollectionInfo.CollectionName);
+
+                IDocumentQuery<JObject> query = client.CreateDocumentQuery<JObject>(collectionUri, "SELECT * FROM c").AsDocumentQuery();
+                while (query.HasMoreResults)
+                {
+                    foreach (JObject lease in await query.ExecuteNextAsync())
+                    {
+                        string leaseId = lease.Value<string>("id");
+                        if (leaseId.Contains(".info") || leaseId.Contains(".lock"))
+                        {
+                            // These are the store initialization marks
+                            continue;
+                        }
+
+                        // create the LeaseToken property
+                        lease.Add("LeaseToken", lease.Value<string>("PartitionId"));
+
+                        lease.Remove("PartitionId");
+
+                        await client.UpsertDocumentAsync(collectionUri, lease);
+                    }
+                }
+            }
+
+            changeFeedProcessorBuilder = await new ChangeFeedProcessorBuilder()
+                    .WithObserverFactory(observerFactory)
+                    .WithHostName("smoke_test")
+                    .WithFeedCollection(this.MonitoredCollectionInfo)
+                    .WithLeaseCollection(this.LeaseCollectionInfo)
+                    .BuildAsync();
+            await changeFeedProcessorBuilder.StartAsync();
+            await Task.Delay(5000);
+
+            // Now all leases are V2 leases, create the rest of the documents
+            using (DocumentClient client = new DocumentClient(this.MonitoredCollectionInfo.Uri, this.MonitoredCollectionInfo.MasterKey, this.MonitoredCollectionInfo.ConnectionPolicy))
+            {
+                Uri collectionUri = UriFactory.CreateDocumentCollectionUri(this.MonitoredCollectionInfo.DatabaseName, this.MonitoredCollectionInfo.CollectionName);
+
+                foreach (int id in expectedIds.TakeLast(10))
+                {
+                    await client.CreateDocumentAsync(collectionUri, new { id = id.ToString() });
+                }
+            }
+
+            // Waiting on all notifications to finish, should be using LeaseToken from the V3 lease
+            await Task.Delay(5000);
+            await changeFeedProcessorBuilder.StopAsync();
+
+            // Verify we processed all items (including when using the V3 leases)
+            Assert.True(!expectedIds.Except(receivedIds).Any() && expectedIds.Count == expectedIds.Count);
+
+
+            // Verify the after-migration leases have both PartitionId and LeaseToken with the same value
+            using (DocumentClient client = new DocumentClient(this.LeaseCollectionInfo.Uri, this.LeaseCollectionInfo.MasterKey, this.LeaseCollectionInfo.ConnectionPolicy))
+            {
+                Uri collectionUri = UriFactory.CreateDocumentCollectionUri(this.LeaseCollectionInfo.DatabaseName, this.LeaseCollectionInfo.CollectionName);
+
+                IDocumentQuery<dynamic> query = client.CreateDocumentQuery<dynamic>(collectionUri, "SELECT * FROM c").AsDocumentQuery();
+                while (query.HasMoreResults)
+                {
+                    foreach (dynamic lease in await query.ExecuteNextAsync())
+                    {
+                        string leaseId = lease.id;
+                        if (leaseId.Contains(".info") || leaseId.Contains(".lock"))
+                        {
+                            // These are the store initialization marks
+                            continue;
+                        }
+
+                        Assert.NotNull(lease.LeaseToken);
+                        Assert.NotNull(lease.PartitionId);
+                        Assert.Equal(lease.LeaseToken, lease.PartitionId);
+                    }
+                }
+            }
+        }
+
+        class TestObserverFactory : FeedProcessing.IChangeFeedObserverFactory, FeedProcessing.IChangeFeedObserver
+        {
+            private readonly Func<FeedProcessing.IChangeFeedObserverContext, IReadOnlyList<Document>, Task> changeProcessor;
+
+            public TestObserverFactory(Func<FeedProcessing.IChangeFeedObserverContext, IReadOnlyList<Document>, Task> changeProcessor)
+            {
+                this.changeProcessor = changeProcessor;
+            }
+
+            public FeedProcessing.IChangeFeedObserver CreateObserver()
+            {
+                return this;
+            }
+
+            public Task OpenAsync(FeedProcessing.IChangeFeedObserverContext context) => Task.CompletedTask;
+
+            public Task CloseAsync(FeedProcessing.IChangeFeedObserverContext context, FeedProcessing.ChangeFeedObserverCloseReason reason) => Task.CompletedTask;
+
+            public Task ProcessChangesAsync(FeedProcessing.IChangeFeedObserverContext context, IReadOnlyList<Document> docs, CancellationToken cancellationToken)
+            {
+                if (this.changeProcessor != null) return this.changeProcessor(context, docs);
+                else return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/src/DocumentDB.ChangeFeedProcessor/LeaseManagement/DocumentServiceLease.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/LeaseManagement/DocumentServiceLease.cs
@@ -16,9 +16,6 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.LeaseManagement
     {
         private static readonly DateTime UnixStartTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
 
-        // Used to detect if the user is migrating from a V3 CFP schema
-        private bool isMigratingFromV3 = false;
-
         public DocumentServiceLease()
         {
         }
@@ -80,19 +77,12 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.LeaseManagement
         {
             get
             {
-                if (this.isMigratingFromV3)
-                {
-                    // If the user migrated the lease from V3 schema, we maintain the LeaseToken property for forward compatibility
-                    return this.PartitionId;
-                }
-
                 return null;
             }
 
             set
             {
                 this.PartitionId = value;
-                this.isMigratingFromV3 = true;
             }
         }
 

--- a/src/DocumentDB.ChangeFeedProcessor/LeaseManagement/DocumentServiceLease.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/LeaseManagement/DocumentServiceLease.cs
@@ -16,6 +16,9 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.LeaseManagement
     {
         private static readonly DateTime UnixStartTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
 
+        // Used to detect if the user is migrating from a V3 CFP schema
+        private bool isMigratingFromV3 = false;
+
         public DocumentServiceLease()
         {
         }
@@ -71,6 +74,27 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.LeaseManagement
 
         [JsonProperty("_ts")]
         private long TS { get; set; }
+
+        [JsonProperty("LeaseToken", NullValueHandling = NullValueHandling.Ignore)]
+        private string LeaseToken
+        {
+            get
+            {
+                if (this.isMigratingFromV3)
+                {
+                    // If the user migrated the lease from V3 schema, we maintain the LeaseToken property for forward compatibility
+                    return this.PartitionId;
+                }
+
+                return null;
+            }
+
+            set
+            {
+                this.PartitionId = value;
+                this.isMigratingFromV3 = true;
+            }
+        }
 
         public static DocumentServiceLease FromDocument(Document document)
         {

--- a/src/DocumentDB.ChangeFeedProcessor/LeaseManagement/DocumentServiceLease.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/LeaseManagement/DocumentServiceLease.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.LeaseManagement
         [JsonProperty("_ts")]
         private long TS { get; set; }
 
+        // Used for migration scenarios from V3, in case the user migrates to V3 and later rollbacks to V2.
         [JsonProperty("LeaseToken", NullValueHandling = NullValueHandling.Ignore)]
         private string LeaseToken
         {

--- a/src/DocumentDB.ChangeFeedProcessor/LeaseManagement/DocumentServiceLease.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/LeaseManagement/DocumentServiceLease.cs
@@ -75,11 +75,6 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.LeaseManagement
         [JsonProperty("LeaseToken", NullValueHandling = NullValueHandling.Ignore)]
         private string LeaseToken
         {
-            get
-            {
-                return null;
-            }
-
             set
             {
                 this.PartitionId = value;


### PR DESCRIPTION
CFP V3 added backward and forward compatibility with CFP V2 (https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1733) by making sure that if the lease document came from V2 with a `PartitionId` property, the new V3 schema will honor it and maintain the `PartitionId` property (plus the V3 `LeaseToken`) in case the user decided to roll back to V2 for some reason.

There could be a scenario though where the user has been running in V3 enough for a split to happen, and these children leases would be use the V3 Schema (no V2 compatibility) since these are lease documents created entirely on V3.

This PR adds compatibility on CFP V2 to detect and understand a CFP V3 lease by detecting the `LeaseToken` property and treating it as the `PartitionId` property when deserializing.

The PR also adds tests to verify the scenario.