### PR TITLE
Bump version to 2.4.0.

### DIFF
--- a/src/DocumentDB.ChangeFeedProcessor/DocumentDB.ChangeFeedProcessor.csproj
+++ b/src/DocumentDB.ChangeFeedProcessor/DocumentDB.ChangeFeedProcessor.csproj
@@ -21,7 +21,7 @@
     <AssemblyName>Microsoft.Azure.Documents.ChangeFeedProcessor</AssemblyName>
 
     <PackageId>Microsoft.Azure.DocumentDB.ChangeFeedProcessor</PackageId>
-    <PackageVersion>2.3.2</PackageVersion>
+    <PackageVersion>2.4.0</PackageVersion>
     <Title>Microsoft Azure Cosmos DB Change Feed Processor library</Title>
     <Authors>Microsoft</Authors>
     <PackageLicenseUrl>http://go.microsoft.com/fwlink/?LinkID=509837</PackageLicenseUrl>
@@ -44,9 +44,9 @@
     <!--CS1587:XML comment is not placed on a valid language element 
     LibLog files have misplaced comments, but we cannot touch them.-->
     <NoWarn>1587</NoWarn>
-    <Version>2.3.2</Version>
-    <AssemblyVersion>2.3.2.0</AssemblyVersion>
-    <FileVersion>2.3.2.0</FileVersion>
+    <Version>2.4.0</Version>
+    <AssemblyVersion>2.4.0.0</AssemblyVersion>
+    <FileVersion>2.4.0.0</FileVersion>
     <PackageReleaseNotes>The change log for this project is available at https://docs.microsoft.com/azure/cosmos-db/sql-api-sdk-dotnet-changefeed.
 </PackageReleaseNotes>
   </PropertyGroup>

--- a/src/DocumentDB.ChangeFeedProcessor/Utils/DocumentCollectionHelper.cs
+++ b/src/DocumentDB.ChangeFeedProcessor/Utils/DocumentCollectionHelper.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Documents.ChangeFeedProcessor.Utils
 
     internal static class DocumentCollectionHelper
     {
-        private const string DefaultUserAgentSuffix = "changefeed-2.3.2";
+        private const string DefaultUserAgentSuffix = "changefeed-2.4.0";
 
         public static DocumentCollectionInfo Canonicalize(this DocumentCollectionInfo collectionInfo)
         {


### PR DESCRIPTION
In this version: support for lease collection that can be partitioned by /partitionKey property. Before lease collection had to be partitioned by /id only. This enables lease collections to be created for Gremlin accounts (Gremlin collections cannot be partitioned by /id).